### PR TITLE
Switch PyPI publishing to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -232,8 +232,6 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
   publish-npm-platforms:
     name: Publish npm platform packages


### PR DESCRIPTION
## Summary

- Remove the `password: ${{ secrets.PYPI_API_TOKEN }}` parameter from the PyPI publish step in the bindings workflow, so the action authenticates via OIDC instead of an API token

The job already has `id-token: write` permission and a `pypi` environment, so removing the password is the only code change needed. This lets PyPI cryptographically verify the link between the published package and this source repository, which marks the project URLs (Homepage, Repository, Issues) as **verified** on pypi.org.

## Manual setup required

Before the next tagged release, a **Trusted Publisher** must be added on PyPI:

1. Go to https://pypi.org/manage/project/httpcloak/settings/publishing/
2. Add a new GitHub publisher:
   - **Owner:** `sardanioss`
   - **Repository:** `httpcloak`
   - **Workflow name:** `bindings.yml`
   - **Environment name:** `pypi`
3. After a successful publish using OIDC, the `PYPI_API_TOKEN` repository secret can be removed

## Test plan

- [x] Diff only removes the two lines (`with:` / `password:`)
- [ ] Configure the Trusted Publisher on pypi.org before the next release
- [ ] Verify the next tagged release publishes to PyPI successfully via OIDC
- [ ] Remove the `PYPI_API_TOKEN` secret afterward