### PR TITLE
Fix streaming fallback for HTTP/1-only servers

### DIFF
--- a/transport/stream.go
+++ b/transport/stream.go
@@ -6,6 +6,7 @@ import (
 	"compress/flate"
 	"compress/gzip"
 	"context"
+	"errors"
 	"io"
 	"net/url"
 	"strings"
@@ -171,9 +172,11 @@ func (t *Transport) doStreamAuto(ctx context.Context, req *Request) (*StreamResp
 				// the H3 error instead of silently sending a truncated request.
 				return nil, err
 			}
-			return t.doStreamHTTP2(ctx, req)
-		case ProtocolHTTP2, ProtocolHTTP1:
-			return t.doStreamHTTP2(ctx, req)
+			return t.doStreamHTTP2OrHTTP1(ctx, req)
+		case ProtocolHTTP2:
+			return t.doStreamHTTP2OrHTTP1(ctx, req)
+		case ProtocolHTTP1:
+			return t.doStreamHTTP1(ctx, req)
 		}
 	}
 
@@ -188,9 +191,12 @@ func (t *Transport) doStreamAuto(ctx context.Context, req *Request) (*StreamResp
 		case decision.err != nil:
 			return nil, decision.err
 		case decision.alpnErr != nil:
-			// Streaming has no H1-conn-reuse path; drop the probe conn and let
-			// the H2 attempt below negotiate on its own.
 			decision.alpnErr.TLSConn.Close()
+			resp, err := t.doStreamHTTP1(ctx, req)
+			if err == nil {
+				t.cacheProtocol(host, ProtocolHTTP1)
+			}
+			return resp, err
 		case decision.protocol == ProtocolHTTP3:
 			resp, err := t.doStreamHTTP3(ctx, req)
 			if err == nil {
@@ -205,11 +211,28 @@ func (t *Transport) doStreamAuto(ctx context.Context, req *Request) (*StreamResp
 		}
 	}
 
-	resp, err := t.doStreamHTTP2(ctx, req)
+	resp, err := t.doStreamHTTP2OrHTTP1(ctx, req)
 	if err == nil {
-		t.cacheProtocol(host, ProtocolHTTP2)
+		if resp.Protocol == "h1" {
+			t.cacheProtocol(host, ProtocolHTTP1)
+		} else {
+			t.cacheProtocol(host, ProtocolHTTP2)
+		}
 	}
 	return resp, err
+}
+
+func (t *Transport) doStreamHTTP2OrHTTP1(ctx context.Context, req *Request) (*StreamResponse, error) {
+	resp, err := t.doStreamHTTP2(ctx, req)
+	if err == nil {
+		return resp, nil
+	}
+	var alpnErr *ALPNMismatchError
+	if errors.As(err, &alpnErr) {
+		alpnErr.TLSConn.Close()
+		return t.doStreamHTTP1(ctx, req)
+	}
+	return nil, err
 }
 
 // doStreamHTTP1 executes a streaming request over HTTP/1.1

--- a/transport/stream_test.go
+++ b/transport/stream_test.go
@@ -4,8 +4,12 @@ import (
 	"bytes"
 	"compress/flate"
 	"compress/gzip"
+	"context"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/andybalholm/brotli"
 	"github.com/klauspost/compress/zstd"
@@ -137,5 +141,36 @@ func TestSetupStreamDecompressor_CaseInsensitive(t *testing.T) {
 	}
 	if string(result) != "test" {
 		t.Errorf("Case insensitive test failed")
+	}
+}
+
+func TestDoStreamAutoFallsBackToHTTP1OnALPNMismatch(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	tr := NewTransport("chrome-latest")
+	defer tr.Close()
+	tr.SetInsecureSkipVerify(true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := tr.DoStream(ctx, &Request{Method: "GET", URL: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Close()
+
+	body, err := io.ReadAll(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "ok" {
+		t.Fatalf("body = %q, want ok", body)
+	}
+	if resp.Protocol != "h1" {
+		t.Fatalf("protocol = %q, want h1", resp.Protocol)
 	}
 }

--- a/transport/stream_test.go
+++ b/transport/stream_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/flate"
 	"compress/gzip"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -172,5 +173,25 @@ func TestDoStreamAutoFallsBackToHTTP1OnALPNMismatch(t *testing.T) {
 	}
 	if resp.Protocol != "h1" {
 		t.Fatalf("protocol = %q, want h1", resp.Protocol)
+	}
+}
+
+func TestDoStreamForcedHTTP2DoesNotFallbackToHTTP1(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	tr := NewTransport("chrome-latest")
+	defer tr.Close()
+	tr.SetInsecureSkipVerify(true)
+	tr.SetProtocol(ProtocolHTTP2)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := tr.DoStream(ctx, &Request{Method: "GET", URL: srv.URL})
+	if !errors.Is(err, ErrALPNMismatch) {
+		t.Fatalf("err = %v, want ALPN mismatch", err)
 	}
 }


### PR DESCRIPTION
- fix `DoStream` auto mode falling through to an HTTP/2 ALPN mismatch on servers that negotiate `http/1.1`
- cache/use HTTP/1 correctly for stream requests when ALPN selects H1
- keep forced HTTP/2 strict: explicit H2 still returns ALPN mismatch instead of silently falling back

Progress towards fixing #75. There are still intermittent fails for stream starts, but I have found that this reduces them.