### PR TITLE
Support Python 3.14t (Free-Threaded / No-GIL)

### DIFF
--- a/bindings/python/httpcloak/client.py
+++ b/bindings/python/httpcloak/client.py
@@ -19,7 +19,7 @@ Example:
 
 import asyncio
 import base64
-import json
+import json as std_json
 import mimetypes
 import os
 import platform
@@ -32,6 +32,13 @@ from pathlib import Path
 from typing import Any, BinaryIO, Dict, List, Optional, Tuple, Union
 from urllib.parse import quote, urlencode
 
+# Faster json support via msgspec
+try:
+    import msgspec
+    _MSGSPEC_AVAILABLE = True
+except ImportError:
+    _MSGSPEC_AVAILABLE = False
+
 # File type for files parameter
 FileValue = Union[
     bytes,                                          # Raw bytes
@@ -43,6 +50,24 @@ FileValue = Union[
 ]
 FilesType = Dict[str, FileValue]
 
+
+
+def _json_loads(data: Union[str, bytes, bytearray, memoryview]) -> Any:
+    """Fast JSON parsing, falling back to stdlib."""
+    if _MSGSPEC_AVAILABLE:
+        # msgspec decodes bytes/memoryviews natively, skipping utf-8 string allocation
+        return msgspec.json.decode(data)
+    
+    # Standard json requires strings or bytes, but handles memoryview poorly in some versions
+    if isinstance(data, memoryview):
+        data = bytes(data)
+    return std_json.loads(data)
+
+def _json_dumps_bytes(obj: Any) -> bytes:
+    """Fast JSON encoding directly to bytes for C-lib IPC."""
+    if _MSGSPEC_AVAILABLE:
+        return msgspec.json.encode(obj)
+    return std_json.dumps(obj).encode("utf-8")
 
 def _encode_multipart(
     data: Optional[Dict[str, str]] = None,
@@ -434,7 +459,10 @@ class Response:
 
     def json(self, **kwargs) -> Any:
         """Parse response body as JSON."""
-        return json.loads(self.text, **kwargs)
+        if _MSGSPEC_AVAILABLE and not kwargs:
+            # ZERO-COPY JSON PARSING: reads straight from the Go-allocated memoryview!
+            return msgspec.json.decode(self.content)
+        return std_json.loads(self.text, **kwargs)
 
     def raise_for_status(self):
         """Raise HTTPCloakError if status_code >= 400."""
@@ -598,7 +626,9 @@ class FastResponse:
 
     def json(self, **kwargs) -> Any:
         """Parse response body as JSON (creates a copy)."""
-        return json.loads(self.text, **kwargs)
+        if _MSGSPEC_AVAILABLE and not kwargs:
+            return msgspec.json.decode(self.content)
+        return std_json.loads(self.text, **kwargs)
 
     def raise_for_status(self):
         """Raise HTTPCloakError if status_code >= 400."""
@@ -644,7 +674,7 @@ class _FastBufferPool:
             return self._buffers[tier_size], self._ctypes_ptrs[tier_size], tier_size
 
 
-# Global fast buffer pool (one per process)
+# Global fast buffer pool (one per thread)
 _fast_pool_local = threading.local()
 
 def _get_fast_buffer_pool() -> _FastBufferPool:
@@ -1301,13 +1331,13 @@ def _parse_raw_response(lib, response_handle: int, elapsed: float = 0.0) -> Resp
         if meta_ptr is None or meta_ptr == 0:
             raise HTTPCloakError("Failed to get response metadata")
 
-        meta_str = cast(meta_ptr, c_char_p).value
+        meta_bytes = cast(meta_ptr, c_char_p).value
         lib.httpcloak_free_string(meta_ptr)
 
-        if meta_str is None:
+        if meta_bytes is None:
             raise HTTPCloakError("Empty response metadata")
 
-        data = json.loads(meta_str.decode("utf-8"))
+        data = _json_loads(meta_bytes)
         if "error" in data:
             raise HTTPCloakError(data["error"])
 
@@ -1717,7 +1747,7 @@ class Session:
         if tcp_df is not None:
             config["tcp_df"] = tcp_df
 
-        config_json = json.dumps(config).encode("utf-8")
+        config_json = _json_dumps_bytes(config)
         self._handle = self._lib.httpcloak_session_new(config_json)
 
         if self._handle == 0:

--- a/bindings/python/httpcloak/client.py
+++ b/bindings/python/httpcloak/client.py
@@ -23,15 +23,14 @@ import json
 import mimetypes
 import os
 import platform
+import threading
 import time
 import uuid
-from ctypes import c_char_p, c_int, c_int64, c_void_p, cdll, cast, CFUNCTYPE, POINTER
+from ctypes import CFUNCTYPE, POINTER, c_char_p, c_int, c_int64, c_void_p, cast, cdll
 from io import IOBase
 from pathlib import Path
-from threading import Lock
 from typing import Any, BinaryIO, Dict, List, Optional, Tuple, Union
-from urllib.parse import urlencode, quote
-
+from urllib.parse import quote, urlencode
 
 # File type for files parameter
 FileValue = Union[
@@ -619,7 +618,7 @@ class _FastBufferPool:
     def __init__(self):
         self._buffers: Dict[int, bytearray] = {}
         self._ctypes_ptrs: Dict[int, Any] = {}
-        self._lock = Lock()
+        self._lock = threading.Lock()
 
     def get_buffer(self, size: int) -> Tuple[bytearray, Any, int]:
         """
@@ -646,7 +645,12 @@ class _FastBufferPool:
 
 
 # Global fast buffer pool (one per process)
-_fast_buffer_pool = _FastBufferPool()
+_fast_pool_local = threading.local()
+
+def _get_fast_buffer_pool() -> _FastBufferPool:
+    if not hasattr(_fast_pool_local, "pool"):
+        _fast_pool_local.pool = _FastBufferPool()
+    return _fast_pool_local.pool
 
 
 class StreamResponse:
@@ -885,7 +889,7 @@ def _get_lib_path() -> str:
 
 
 _lib = None
-_lib_lock = Lock()
+_lib_lock = threading.Lock()
 
 
 def _get_lib():
@@ -895,8 +899,9 @@ def _get_lib():
         with _lib_lock:
             if _lib is None:
                 lib_path = _get_lib_path()
-                _lib = cdll.LoadLibrary(lib_path)
-                _setup_lib(_lib)
+                new_lib = cdll.LoadLibrary(lib_path)
+                _setup_lib(new_lib)
+                _lib = new_lib  # Assign only after fully configured
     return _lib
 
 
@@ -931,7 +936,7 @@ class _AsyncCallbackManager:
     """
 
     def __init__(self):
-        self._lock = Lock()
+        self._lock = threading.Lock()
         # Pending requests: callback_id -> (future, loop, start_time)
         self._pending: Dict[int, Tuple[asyncio.Future, asyncio.AbstractEventLoop, float]] = {}
         self._callback_ref: Optional[ASYNC_CALLBACK] = None  # prevent GC
@@ -1025,7 +1030,7 @@ class _AsyncCallbackManager:
 
 # Global async callback manager
 _async_manager: Optional[_AsyncCallbackManager] = None
-_async_manager_lock = Lock()
+_async_manager_lock = threading.Lock()
 
 
 def _get_async_manager() -> _AsyncCallbackManager:
@@ -1387,7 +1392,7 @@ def _parse_fast_response(lib, response_handle: int, elapsed: float = 0.0) -> Fas
 
         if body_len > 0:
             # Get pre-allocated buffer from pool (no allocation!)
-            buf, buf_ptr, buf_size = _fast_buffer_pool.get_buffer(body_len)
+            buf, buf_ptr, buf_size = _get_fast_buffer_pool().get_buffer(body_len)
 
             # Copy directly from Go to pre-allocated Python buffer
             copied = lib.httpcloak_response_copy_body_to(
@@ -4010,7 +4015,7 @@ class Session:
 # =============================================================================
 
 _default_session: Optional[Session] = None
-_default_session_lock = Lock()
+_default_session_lock = threading.Lock()
 _default_config: Dict[str, Any] = {}
 
 
@@ -4542,7 +4547,7 @@ class LocalProxy:
 
 # Global session cache callbacks (must keep references to prevent GC)
 _session_cache_callbacks: Dict[str, Any] = {}
-_session_cache_lock = Lock()
+_session_cache_lock = threading.Lock()
 
 
 class SessionCacheBackend:

--- a/bindings/python/httpcloak/client.py
+++ b/bindings/python/httpcloak/client.py
@@ -19,7 +19,7 @@ Example:
 
 import asyncio
 import base64
-import json as std_json
+import json
 import mimetypes
 import os
 import platform
@@ -32,13 +32,6 @@ from pathlib import Path
 from typing import Any, BinaryIO, Dict, List, Optional, Tuple, Union
 from urllib.parse import quote, urlencode
 
-# Faster json support via msgspec
-try:
-    import msgspec
-    _MSGSPEC_AVAILABLE = True
-except ImportError:
-    _MSGSPEC_AVAILABLE = False
-
 # File type for files parameter
 FileValue = Union[
     bytes,                                          # Raw bytes
@@ -50,24 +43,6 @@ FileValue = Union[
 ]
 FilesType = Dict[str, FileValue]
 
-
-
-def _json_loads(data: Union[str, bytes, bytearray, memoryview]) -> Any:
-    """Fast JSON parsing, falling back to stdlib."""
-    if _MSGSPEC_AVAILABLE:
-        # msgspec decodes bytes/memoryviews natively, skipping utf-8 string allocation
-        return msgspec.json.decode(data)
-    
-    # Standard json requires strings or bytes, but handles memoryview poorly in some versions
-    if isinstance(data, memoryview):
-        data = bytes(data)
-    return std_json.loads(data)
-
-def _json_dumps_bytes(obj: Any) -> bytes:
-    """Fast JSON encoding directly to bytes for C-lib IPC."""
-    if _MSGSPEC_AVAILABLE:
-        return msgspec.json.encode(obj)
-    return std_json.dumps(obj).encode("utf-8")
 
 def _encode_multipart(
     data: Optional[Dict[str, str]] = None,
@@ -459,10 +434,7 @@ class Response:
 
     def json(self, **kwargs) -> Any:
         """Parse response body as JSON."""
-        if _MSGSPEC_AVAILABLE and not kwargs:
-            # ZERO-COPY JSON PARSING: reads straight from the Go-allocated memoryview!
-            return msgspec.json.decode(self.content)
-        return std_json.loads(self.text, **kwargs)
+        return json.loads(self.text, **kwargs)
 
     def raise_for_status(self):
         """Raise HTTPCloakError if status_code >= 400."""
@@ -626,9 +598,7 @@ class FastResponse:
 
     def json(self, **kwargs) -> Any:
         """Parse response body as JSON (creates a copy)."""
-        if _MSGSPEC_AVAILABLE and not kwargs:
-            return msgspec.json.decode(self.content)
-        return std_json.loads(self.text, **kwargs)
+        return json.loads(self.text, **kwargs)
 
     def raise_for_status(self):
         """Raise HTTPCloakError if status_code >= 400."""
@@ -674,7 +644,7 @@ class _FastBufferPool:
             return self._buffers[tier_size], self._ctypes_ptrs[tier_size], tier_size
 
 
-# Global fast buffer pool (one per thread)
+# Global fast buffer pool (one per process)
 _fast_pool_local = threading.local()
 
 def _get_fast_buffer_pool() -> _FastBufferPool:
@@ -1331,13 +1301,13 @@ def _parse_raw_response(lib, response_handle: int, elapsed: float = 0.0) -> Resp
         if meta_ptr is None or meta_ptr == 0:
             raise HTTPCloakError("Failed to get response metadata")
 
-        meta_bytes = cast(meta_ptr, c_char_p).value
+        meta_str = cast(meta_ptr, c_char_p).value
         lib.httpcloak_free_string(meta_ptr)
 
-        if meta_bytes is None:
+        if meta_str is None:
             raise HTTPCloakError("Empty response metadata")
 
-        data = _json_loads(meta_bytes)
+        data = json.loads(meta_str.decode("utf-8"))
         if "error" in data:
             raise HTTPCloakError(data["error"])
 
@@ -1747,7 +1717,7 @@ class Session:
         if tcp_df is not None:
             config["tcp_df"] = tcp_df
 
-        config_json = _json_dumps_bytes(config)
+        config_json = json.dumps(config).encode("utf-8")
         self._handle = self._lib.httpcloak_session_new(config_json)
 
         if self._handle == 0:

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -31,6 +31,9 @@ Documentation = "https://github.com/sardanioss/httpcloak#readme"
 Repository = "https://github.com/sardanioss/httpcloak"
 Issues = "https://github.com/sardanioss/httpcloak/issues"
 
+[project.optional-dependencies]
+fast = ["msgspec>=0.20.0"]
+
 [tool.setuptools.packages.find]
 where = ["."]
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -31,9 +31,6 @@ Documentation = "https://github.com/sardanioss/httpcloak#readme"
 Repository = "https://github.com/sardanioss/httpcloak"
 Issues = "https://github.com/sardanioss/httpcloak/issues"
 
-[project.optional-dependencies]
-fast = ["msgspec>=0.20.0"]
-
 [tool.setuptools.packages.find]
 where = ["."]
 


### PR DESCRIPTION
PR enables httpcloak to be fully compatible with python 3.14 free-threaded. Since httpcloak uses ctypes for it's bindings instead of C-extensions, no-wheel changes were needed.

Changes:

1. Fixed double-checked locking race condition in `_get_lib()` that caused pointer truncation segfaults without the GIL.
2. Moved `_fast_buffer_pool` to `threading.local()` so concurrent requests don't write to the exact same ctypes memory block.

The build process from a cursory examination seems to support free-threaded out of the box. So there wasn't any need to change there.