### PR TITLE
fix(pool): drain retired http2 connections

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1209,7 +1209,14 @@ func (c *Client) doHTTP2(ctx context.Context, host, port string, httpReq *http.R
 	}
 
 	firstByteTime := time.Now()
-	resp, err := conn.HTTP2Conn.RoundTrip(httpReq)
+	resp, err := conn.RoundTrip(httpReq)
+	if err == pool.ErrConnRetired {
+		conn, err = c.poolManager.GetConn(ctx, host, port)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to get replacement connection: %w", err)
+		}
+		resp, err = conn.RoundTrip(httpReq)
+	}
 	if err != nil {
 		return nil, "", fmt.Errorf("request failed: %w", err)
 	}

--- a/client/stream_lifetime_test.go
+++ b/client/stream_lifetime_test.go
@@ -1,0 +1,112 @@
+package client
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDoStreamSurvivesAgedConnectionRetirement(t *testing.T) {
+	writeSecondEvent := make(chan struct{})
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "data: first\n\n")
+		w.(http.Flusher).Flush()
+
+		select {
+		case <-writeSecondEvent:
+			_, _ = fmt.Fprint(w, "data: second\n\n")
+			w.(http.Flusher).Flush()
+		case <-r.Context().Done():
+		}
+	}))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+
+	client := NewClient(
+		"chrome-149",
+		WithForceHTTP2(),
+		WithInsecureSkipVerify(),
+		WithTimeout(5*time.Second),
+	)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	responses := make([]*StreamResponse, 2)
+	readers := make([]*bufio.Reader, len(responses))
+	for i := range responses {
+		resp, err := client.DoStream(ctx, &Request{Method: http.MethodGet, URL: server.URL})
+		if err != nil {
+			t.Fatalf("DoStream %d: %v", i, err)
+		}
+		responses[i] = resp
+		defer responses[i].Close()
+
+		readers[i] = bufio.NewReader(responses[i])
+		if event := readTestSSEEvent(t, readers[i]); event != "data: first\n\n" {
+			t.Fatalf("stream %d first event = %q", i, event)
+		}
+	}
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	host, port, err := net.SplitHostPort(serverURL.Host)
+	if err != nil {
+		t.Fatalf("split server host: %v", err)
+	}
+	hostPool, err := client.poolManager.GetPool(host, port)
+	if err != nil {
+		t.Fatalf("get host pool: %v", err)
+	}
+	streamConn, err := hostPool.GetConn(ctx)
+	if err != nil {
+		t.Fatalf("get stream connection: %v", err)
+	}
+
+	streamConn.CreatedAt = time.Now().Add(-6 * time.Minute)
+	hostPool.CloseIdle()
+
+	replacementConn, err := hostPool.GetConn(ctx)
+	if err != nil {
+		t.Fatalf("get replacement connection: %v", err)
+	}
+	if replacementConn == streamConn {
+		t.Fatal("aged connection remained eligible for new requests")
+	}
+
+	close(writeSecondEvent)
+	for i := range readers {
+		if event := readTestSSEEvent(t, readers[i]); event != "data: second\n\n" {
+			t.Fatalf("stream %d second event = %q", i, event)
+		}
+	}
+}
+
+func readTestSSEEvent(t *testing.T, reader *bufio.Reader) string {
+	t.Helper()
+
+	var event strings.Builder
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read SSE event: %v", err)
+		}
+		event.WriteString(line)
+		if line == "\n" {
+			return event.String()
+		}
+	}
+}

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -13,6 +13,7 @@ import (
 
 	"io"
 
+	http "github.com/sardanioss/http"
 	"github.com/sardanioss/httpcloak/dns"
 	"github.com/sardanioss/httpcloak/fingerprint"
 	"github.com/sardanioss/httpcloak/transport"
@@ -23,8 +24,9 @@ import (
 )
 
 var (
-	ErrPoolClosed    = errors.New("connection pool is closed")
-	ErrNoConnections = errors.New("no available connections")
+	ErrPoolClosed     = errors.New("connection pool is closed")
+	ErrNoConnections  = errors.New("no available connections")
+	ErrConnRetired    = errors.New("connection retired before request started")
 )
 
 // Conn represents a persistent connection
@@ -38,6 +40,8 @@ type Conn struct {
 	UseCount   int64
 	mu         sync.Mutex
 	closed     bool
+	retired    bool
+	inFlight   int
 }
 
 // IsHealthy checks if the connection is still usable
@@ -45,7 +49,7 @@ func (c *Conn) IsHealthy() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.closed {
+	if c.closed || c.retired {
 		return false
 	}
 
@@ -55,6 +59,92 @@ func (c *Conn) IsHealthy() bool {
 	}
 
 	return false
+}
+
+// RoundTrip executes a request and keeps the connection active until the
+// response body reaches EOF or is closed.
+func (c *Conn) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.mu.Lock()
+	if c.closed || c.retired || c.HTTP2Conn == nil {
+		c.mu.Unlock()
+		return nil, ErrConnRetired
+	}
+	c.inFlight++
+	h2Conn := c.HTTP2Conn
+	c.mu.Unlock()
+
+	resp, err := h2Conn.RoundTrip(req)
+	if err != nil {
+		c.release()
+		return nil, err
+	}
+	if resp.Body == nil {
+		c.release()
+		return resp, nil
+	}
+	resp.Body = &trackedBody{
+		ReadCloser: resp.Body,
+		release:    c.release,
+	}
+	return resp, nil
+}
+
+type trackedBody struct {
+	io.ReadCloser
+	release func()
+	once    sync.Once
+}
+
+func (b *trackedBody) Read(p []byte) (int, error) {
+	n, err := b.ReadCloser.Read(p)
+	if err != nil {
+		b.once.Do(b.release)
+	}
+	return n, err
+}
+
+func (b *trackedBody) Close() error {
+	err := b.ReadCloser.Close()
+	b.once.Do(b.release)
+	return err
+}
+
+func (c *Conn) release() {
+	c.mu.Lock()
+	if c.inFlight > 0 {
+		c.inFlight--
+	}
+	closeNow := c.retired && c.inFlight == 0 && !c.closed
+	if closeNow {
+		c.closed = true
+	}
+	tlsConn := c.TLSConn
+	c.mu.Unlock()
+
+	if closeNow && tlsConn != nil {
+		go tlsConn.Close()
+	}
+}
+
+// Retire prevents new requests from using the connection and closes it after
+// all active response bodies have finished.
+func (c *Conn) Retire() {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.retired = true
+	closeNow := c.inFlight == 0
+	if closeNow {
+		c.closed = true
+	}
+	tlsConn := c.TLSConn
+	c.mu.Unlock()
+
+	if closeNow && tlsConn != nil {
+		go tlsConn.Close()
+	}
 }
 
 // Age returns how long the connection has been open
@@ -80,25 +170,17 @@ func (c *Conn) MarkUsed() {
 // Close closes the connection
 func (c *Conn) Close() error {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if c.closed {
+		c.mu.Unlock()
 		return nil
 	}
 	c.closed = true
+	c.retired = true
+	tlsConn := c.TLSConn
+	c.mu.Unlock()
 
-	var errs []error
-	if c.HTTP2Conn != nil {
-		// HTTP/2 connection close is handled by the underlying TLS conn
-	}
-	if c.TLSConn != nil {
-		if err := c.TLSConn.Close(); err != nil {
-			errs = append(errs, err)
-		}
-	}
-
-	if len(errs) > 0 {
-		return errs[0]
+	if tlsConn != nil {
+		return tlsConn.Close()
 	}
 	return nil
 }
@@ -250,7 +332,7 @@ func (p *HostPool) GetConn(ctx context.Context) (*Conn, error) {
 		if conn.IsHealthy() && conn.Age() < p.maxConnAge {
 			healthy = append(healthy, conn)
 		} else {
-			go conn.Close()
+			conn.Retire()
 		}
 	}
 	p.connections = healthy
@@ -941,7 +1023,7 @@ func (p *HostPool) CloseIdle() {
 	active := make([]*Conn, 0, len(p.connections))
 	for _, conn := range p.connections {
 		if conn.IdleTime() > p.maxIdleTime || conn.Age() > p.maxConnAge || !conn.IsHealthy() {
-			go conn.Close()
+			conn.Retire()
 		} else {
 			active = append(active, conn)
 		}


### PR DESCRIPTION
## Summary

Prevent HTTP/2 pool cleanup from closing connections that still carry active streaming response bodies.

Connections that exceed the idle or maximum-age limits are removed from selection immediately, but their underlying TLS connection remains open until all active response bodies reach EOF or are closed. This prevents long-running `DoStream` and SSE requests from failing with `use of closed network connection`.

Fixes #83.

## Changes

- Track active HTTP/2 response bodies on pooled connections.
- Retire aged or unhealthy connections from new work without interrupting active streams.
- Close retired connections after the last tracked body releases its lease.
- Retry once when cleanup retires a selected connection before the transport starts the request.
- Add a multiplexed HTTP/2 SSE regression test covering connection rotation.

## Testing

- `go test -race ./client -run '^TestDoStreamSurvivesAgedConnectionRetirement$' -count=10`
- `go list ./... | rg -v '/examples/' | xargs go test`
- `go list ./... | rg -v '/examples/' | xargs go vet`

## Notes

The repository-wide `go test ./...` and `go vet ./...` commands currently fail in untouched example packages because of duplicate `main` functions, stale example APIs, and existing vet warnings. All non-example library packages pass.
