### PR TITLE
fix: bound proxy handshakes by request context

### DIFF
--- a/pool/pool.go
+++ b/pool/pool.go
@@ -730,6 +730,12 @@ func (p *HostPool) dialHTTPProxy(ctx context.Context, proxy *proxyConfig) (net.C
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to proxy: %w", err)
 	}
+	clearDeadline, err := armProxyHandshakeDeadline(ctx, conn, p.connectTimeout)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("failed to set proxy handshake deadline: %w", err)
+	}
+	defer clearDeadline()
 
 	// Send CONNECT request
 	targetAddr := net.JoinHostPort(p.host, p.port)
@@ -789,6 +795,12 @@ func (p *HostPool) dialSOCKS5Proxy(ctx context.Context, proxy *proxyConfig) (net
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to SOCKS5 proxy: %w", err)
 	}
+	clearDeadline, err := armProxyHandshakeDeadline(ctx, conn, p.connectTimeout)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("failed to set SOCKS5 handshake deadline: %w", err)
+	}
+	defer clearDeadline()
 
 	// SOCKS5 handshake
 	// Version 5, 1 auth method (no auth or username/password)

--- a/pool/proxy_deadline.go
+++ b/pool/proxy_deadline.go
@@ -1,0 +1,36 @@
+package pool
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+// armProxyHandshakeDeadline bounds all reads and writes performed while negotiating
+// a proxy tunnel. Cancelling the context interrupts an in-flight socket operation.
+func armProxyHandshakeDeadline(
+	ctx context.Context,
+	connection net.Conn,
+	fallback time.Duration,
+) (func(), error) {
+	deadline := time.Now().Add(fallback)
+	if contextDeadline, ok := ctx.Deadline(); ok && contextDeadline.Before(deadline) {
+		deadline = contextDeadline
+	}
+	if err := connection.SetDeadline(deadline); err != nil {
+		return nil, err
+	}
+
+	cancellationApplied := make(chan struct{})
+	stopCancellation := context.AfterFunc(ctx, func() {
+		_ = connection.SetDeadline(time.Now())
+		close(cancellationApplied)
+	})
+
+	return func() {
+		if !stopCancellation() {
+			<-cancellationApplied
+		}
+		_ = connection.SetDeadline(time.Time{})
+	}, nil
+}

--- a/pool/proxy_deadline_test.go
+++ b/pool/proxy_deadline_test.go
@@ -1,0 +1,199 @@
+package pool
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/sardanioss/httpcloak/fingerprint"
+)
+
+func TestProxyHandshakeDeadlineInterruptsStalledRead(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	clearDeadline, err := armProxyHandshakeDeadline(ctx, client, time.Second)
+	if err != nil {
+		t.Fatalf("armProxyHandshakeDeadline() error = %v", err)
+	}
+	defer clearDeadline()
+
+	startedAt := time.Now()
+	_, err = client.Read(make([]byte, 1))
+	if err == nil {
+		t.Fatal("Read() unexpectedly succeeded")
+	}
+	if elapsed := time.Since(startedAt); elapsed > 500*time.Millisecond {
+		t.Fatalf("stalled read exceeded context deadline: %v", elapsed)
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("context deadline did not fire")
+	}
+	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("context error = %v, want DeadlineExceeded", ctx.Err())
+	}
+}
+
+func TestProxyHandshakeCancellationInterruptsStalledWrite(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	clearDeadline, err := armProxyHandshakeDeadline(ctx, client, time.Second)
+	if err != nil {
+		t.Fatalf("armProxyHandshakeDeadline() error = %v", err)
+	}
+	defer clearDeadline()
+
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := client.Write(make([]byte, 1024))
+		writeDone <- err
+	}()
+	cancel()
+
+	select {
+	case err := <-writeDone:
+		if err == nil {
+			t.Fatal("Write() unexpectedly succeeded")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("cancelled proxy write did not return")
+	}
+}
+
+func TestProxyHandshakeClearsDeadlineAfterNegotiation(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	clearDeadline, err := armProxyHandshakeDeadline(context.Background(), client, 20*time.Millisecond)
+	if err != nil {
+		t.Fatalf("armProxyHandshakeDeadline() error = %v", err)
+	}
+	clearDeadline()
+	time.Sleep(30 * time.Millisecond)
+
+	go func() {
+		_, _ = server.Write([]byte{1})
+	}()
+	buffer := make([]byte, 1)
+	if _, err := client.Read(buffer); err != nil {
+		t.Fatalf("Read() after clearing deadline error = %v", err)
+	}
+}
+
+func TestHTTPProxyHandshakeUsesContextDeadline(t *testing.T) {
+	t.Parallel()
+
+	proxy, done := newStalledProxy(t)
+	host, port, err := net.SplitHostPort(proxy)
+	if err != nil {
+		t.Fatalf("SplitHostPort() error = %v", err)
+	}
+	pool := &HostPool{
+		host:           "example.invalid",
+		port:           "443",
+		preset:         fingerprint.GetStrict("chrome-150-windows"),
+		connectTimeout: time.Second,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	startedAt := time.Now()
+	_, err = pool.dialHTTPProxy(ctx, &proxyConfig{
+		Scheme: "http",
+		Host:   host,
+		Port:   port,
+	})
+	if err == nil {
+		t.Fatal("dialHTTPProxy() unexpectedly succeeded")
+	}
+	if elapsed := time.Since(startedAt); elapsed > 500*time.Millisecond {
+		t.Fatalf("HTTP proxy handshake exceeded context deadline: %v", elapsed)
+	}
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("HTTP proxy connection remained open after deadline")
+	}
+}
+
+func TestSOCKS5ProxyHandshakeUsesContextDeadline(t *testing.T) {
+	t.Parallel()
+
+	proxy, done := newStalledProxy(t)
+	host, port, err := net.SplitHostPort(proxy)
+	if err != nil {
+		t.Fatalf("SplitHostPort() error = %v", err)
+	}
+	pool := &HostPool{
+		host:           "example.invalid",
+		port:           "443",
+		preset:         fingerprint.GetStrict("chrome-150-windows"),
+		connectTimeout: time.Second,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	startedAt := time.Now()
+	_, err = pool.dialSOCKS5Proxy(ctx, &proxyConfig{
+		Scheme: "socks5",
+		Host:   host,
+		Port:   port,
+	})
+	if err == nil {
+		t.Fatal("dialSOCKS5Proxy() unexpectedly succeeded")
+	}
+	if elapsed := time.Since(startedAt); elapsed > 500*time.Millisecond {
+		t.Fatalf("SOCKS5 proxy handshake exceeded context deadline: %v", elapsed)
+	}
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("SOCKS5 proxy connection remained open after deadline")
+	}
+}
+
+func newStalledProxy(t *testing.T) (string, <-chan struct{}) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		connection, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		_, _ = io.Copy(io.Discard, connection)
+		_ = connection.Close()
+	}()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Error("stalled proxy fixture did not stop")
+		}
+	})
+	return listener.Addr().String(), done
+}


### PR DESCRIPTION
## Summary

- apply one context-aware socket deadline guard to shared HTTP CONNECT and SOCKS5 proxy negotiation
- interrupt blocked proxy reads and writes immediately when the request context is cancelled
- clear the temporary socket deadline after a successful tunnel handshake
- add focused deadline, cancellation, cleanup, HTTP proxy, and SOCKS5 proxy regression tests

## Root cause

The shared host pool used `DialContext` for the initial TCP connection, but subsequent proxy handshake reads and writes had no socket deadline. A proxy that accepted TCP and then stopped responding could therefore outlive the caller context and configured request timeout.

## Verification

- `GOTOOLCHAIN=go1.26.5 go test -race -count=10 ./pool`
- `GOTOOLCHAIN=go1.26.5 go test -race ./pool ./client ./transport`

A blanket `go test ./...` still reports pre-existing failures in example directories, including duplicate `main` declarations, stale example APIs, and vet errors. The affected pool, client, and transport suites pass.