### PR TITLE
fix: preserve signature overrides in pooled handshakes

### DIFF
--- a/pool/client_hello.go
+++ b/pool/client_hello.go
@@ -1,0 +1,14 @@
+package pool
+
+import (
+	"github.com/sardanioss/httpcloak/fingerprint"
+	utls "github.com/sardanioss/utls"
+)
+
+func tcpClientHelloSpec(preset *fingerprint.Preset, id utls.ClientHelloID, seed int64) (*utls.ClientHelloSpec, error) {
+	return fingerprint.SpecFor(id, seed, preset.SignatureAlgorithms)
+}
+
+func quicClientHelloSpec(preset *fingerprint.Preset, id utls.ClientHelloID, seed int64) (*utls.ClientHelloSpec, error) {
+	return fingerprint.SpecFor(id, seed, preset.QUICSignatureAlgorithms)
+}

--- a/pool/client_hello_test.go
+++ b/pool/client_hello_test.go
@@ -1,0 +1,69 @@
+package pool
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/sardanioss/httpcloak/fingerprint"
+	utls "github.com/sardanioss/utls"
+)
+
+func TestTCPClientHelloSpecAppliesPresetSignatureAlgorithms(t *testing.T) {
+	preset := fingerprint.GetStrict("chrome-150-windows")
+	if preset == nil {
+		t.Fatal("chrome-150-windows preset is unavailable")
+	}
+
+	spec, err := tcpClientHelloSpec(preset, preset.ClientHelloID, 42)
+	if err != nil {
+		t.Fatalf("tcpClientHelloSpec() error = %v", err)
+	}
+	if got := signatureAlgorithms(spec); !slices.Equal(got, preset.SignatureAlgorithms) {
+		t.Fatalf("signature algorithms = %v, want %v", got, preset.SignatureAlgorithms)
+	}
+
+	manager := NewManager(preset)
+	t.Cleanup(manager.Close)
+	if got := signatureAlgorithms(manager.cachedSpec); !slices.Equal(got, preset.SignatureAlgorithms) {
+		t.Fatalf("manager cached signature algorithms = %v, want %v", got, preset.SignatureAlgorithms)
+	}
+	if manager.cachedPSKSpec != nil {
+		if got := signatureAlgorithms(manager.cachedPSKSpec); !slices.Equal(got, preset.SignatureAlgorithms) {
+			t.Fatalf("manager cached PSK signature algorithms = %v, want %v", got, preset.SignatureAlgorithms)
+		}
+	}
+}
+
+func TestQUICClientHelloSpecUsesIndependentOverride(t *testing.T) {
+	preset := fingerprint.GetStrict("chrome-150-windows")
+	if preset == nil {
+		t.Fatal("chrome-150-windows preset is unavailable")
+	}
+	preset.QUICSignatureAlgorithms = []utls.SignatureScheme{0x1234, 0x5678}
+
+	spec, err := quicClientHelloSpec(preset, preset.QUICClientHelloID, 42)
+	if err != nil {
+		t.Fatalf("quicClientHelloSpec() error = %v", err)
+	}
+	if got := signatureAlgorithms(spec); !slices.Equal(got, preset.QUICSignatureAlgorithms) {
+		t.Fatalf("QUIC signature algorithms = %v, want %v", got, preset.QUICSignatureAlgorithms)
+	}
+
+	manager := NewQUICManager(preset, nil)
+	t.Cleanup(manager.Close)
+	if got := signatureAlgorithms(manager.cachedSpec); !slices.Equal(got, preset.QUICSignatureAlgorithms) {
+		t.Fatalf("QUIC manager cached signature algorithms = %v, want %v", got, preset.QUICSignatureAlgorithms)
+	}
+}
+
+func signatureAlgorithms(spec *utls.ClientHelloSpec) []utls.SignatureScheme {
+	if spec == nil {
+		return nil
+	}
+	for _, extension := range spec.Extensions {
+		if algorithms, ok := extension.(*utls.SignatureAlgorithmsExtension); ok {
+			return algorithms.SupportedSignatureAlgorithms
+		}
+	}
+	return nil
+}

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -155,12 +155,12 @@ func NewHostPool(host, port string, preset *fingerprint.Preset, dnsCache *dns.Ca
 		if spec, err := fingerprint.ParseJA3(preset.JA3, preset.JA3Extras); err == nil {
 			cachedSpec = spec
 		}
-	} else if spec, err := utls.UTLSIdToSpecWithSeed(preset.ClientHelloID, shuffleSeed); err == nil {
-		cachedSpec = &spec
+	} else if spec, err := tcpClientHelloSpec(preset, preset.ClientHelloID, shuffleSeed); err == nil {
+		cachedSpec = spec
 	}
 	if preset.JA3 == "" && preset.PSKClientHelloID.Client != "" {
-		if spec, err := utls.UTLSIdToSpecWithSeed(preset.PSKClientHelloID, shuffleSeed); err == nil {
-			cachedPSKSpec = &spec
+		if spec, err := tcpClientHelloSpec(preset, preset.PSKClientHelloID, shuffleSeed); err == nil {
+			cachedPSKSpec = spec
 		}
 	}
 	return NewHostPoolWithConfig(host, "", port, preset, dnsCache, false, "", cachedSpec, cachedPSKSpec, shuffleSeed, nil)
@@ -348,16 +348,16 @@ func (p *HostPool) createConn(ctx context.Context) (*Conn, error) {
 	}
 
 	tlsConfig := &utls.Config{
-		ServerName:                          p.sniHost,
-		InsecureSkipVerify:                  p.insecureSkipVerify,
-		MinVersion:                          minVersion,
-		MaxVersion:                          tls.VersionTLS13,
-		SessionTicketsDisabled:              false,         // Enable session tickets
-		ClientSessionCache:                  sessionCache,  // Only set when PSK is available
-		OmitEmptyPsk:                        true,          // Chrome doesn't send empty PSK on first connection
-		PreferSkipResumptionOnNilExtension:  true,          // Safety net: skip resumption if spec lacks PSK extension
-		EncryptedClientHelloConfigList:      echConfigList, // ECH configuration (if available)
-		KeyLogWriter:                        keyLogWriter,
+		ServerName:                         p.sniHost,
+		InsecureSkipVerify:                 p.insecureSkipVerify,
+		MinVersion:                         minVersion,
+		MaxVersion:                         tls.VersionTLS13,
+		SessionTicketsDisabled:             false,         // Enable session tickets
+		ClientSessionCache:                 sessionCache,  // Only set when PSK is available
+		OmitEmptyPsk:                       true,          // Chrome doesn't send empty PSK on first connection
+		PreferSkipResumptionOnNilExtension: true,          // Safety net: skip resumption if spec lacks PSK extension
+		EncryptedClientHelloConfigList:     echConfigList, // ECH configuration (if available)
+		KeyLogWriter:                       keyLogWriter,
 	}
 
 	// Generate fresh spec for this connection to avoid race condition
@@ -377,14 +377,14 @@ func (p *HostPool) createConn(ctx context.Context) (*Conn, error) {
 	} else if p.cachedPSKSpec != nil && p.preset.PSKClientHelloID.Client != "" {
 		// Prefer PSK spec when available - Chrome always includes PSK extension structure
 		// Generate fresh PSK spec for this connection
-		if spec, err := utls.UTLSIdToSpecWithSeed(p.preset.PSKClientHelloID, p.shuffleSeed); err == nil {
-			specToUse = &spec
+		if spec, err := tcpClientHelloSpec(p.preset, p.preset.PSKClientHelloID, p.shuffleSeed); err == nil {
+			specToUse = spec
 		}
 	}
 	if specToUse == nil && p.cachedSpec != nil && p.preset.JA3 == "" {
 		// Generate fresh regular spec
-		if spec, err := utls.UTLSIdToSpecWithSeed(p.preset.ClientHelloID, p.shuffleSeed); err == nil {
-			specToUse = &spec
+		if spec, err := tcpClientHelloSpec(p.preset, p.preset.ClientHelloID, p.shuffleSeed); err == nil {
+			specToUse = spec
 		}
 	}
 
@@ -1036,14 +1036,14 @@ func NewManagerWithTLSConfig(preset *fingerprint.Preset, insecureSkipVerify bool
 		if spec, err := fingerprint.ParseJA3(preset.JA3, preset.JA3Extras); err == nil {
 			m.cachedSpec = spec
 		}
-	} else if spec, err := utls.UTLSIdToSpecWithSeed(preset.ClientHelloID, shuffleSeed); err == nil {
-		m.cachedSpec = &spec
+	} else if spec, err := tcpClientHelloSpec(preset, preset.ClientHelloID, shuffleSeed); err == nil {
+		m.cachedSpec = spec
 	}
 
 	// Also cache PSK variant if available (not applicable for JA3 presets)
 	if preset.JA3 == "" && preset.PSKClientHelloID.Client != "" {
-		if spec, err := utls.UTLSIdToSpecWithSeed(preset.PSKClientHelloID, shuffleSeed); err == nil {
-			m.cachedPSKSpec = &spec
+		if spec, err := tcpClientHelloSpec(preset, preset.PSKClientHelloID, shuffleSeed); err == nil {
+			m.cachedPSKSpec = spec
 		}
 	}
 
@@ -1077,14 +1077,14 @@ func NewManagerWithProxy(preset *fingerprint.Preset, proxyURL string, insecureSk
 		if spec, err := fingerprint.ParseJA3(preset.JA3, preset.JA3Extras); err == nil {
 			m.cachedSpec = spec
 		}
-	} else if spec, err := utls.UTLSIdToSpecWithSeed(preset.ClientHelloID, shuffleSeed); err == nil {
-		m.cachedSpec = &spec
+	} else if spec, err := tcpClientHelloSpec(preset, preset.ClientHelloID, shuffleSeed); err == nil {
+		m.cachedSpec = spec
 	}
 
 	// Also cache PSK variant if available (not applicable for JA3 presets)
 	if preset.JA3 == "" && preset.PSKClientHelloID.Client != "" {
-		if spec, err := utls.UTLSIdToSpecWithSeed(preset.PSKClientHelloID, shuffleSeed); err == nil {
-			m.cachedPSKSpec = &spec
+		if spec, err := tcpClientHelloSpec(preset, preset.PSKClientHelloID, shuffleSeed); err == nil {
+			m.cachedPSKSpec = spec
 		}
 	}
 

--- a/pool/quic_pool.go
+++ b/pool/quic_pool.go
@@ -172,14 +172,14 @@ func NewQUICHostPool(host, port string, preset *fingerprint.Preset, dnsCache *dn
 	shuffleSeed := int64(binary.LittleEndian.Uint64(seedBytes[:]))
 
 	if preset != nil && preset.QUICClientHelloID.Client != "" {
-		if spec, err := utls.UTLSIdToSpecWithSeed(preset.QUICClientHelloID, shuffleSeed); err == nil {
-			cachedSpec = &spec
+		if spec, err := quicClientHelloSpec(preset, preset.QUICClientHelloID, shuffleSeed); err == nil {
+			cachedSpec = spec
 		}
 	}
 	// Also generate PSK spec for session resumption
 	if preset != nil && preset.QUICPSKClientHelloID.Client != "" {
-		if spec, err := utls.UTLSIdToSpecWithSeed(preset.QUICPSKClientHelloID, shuffleSeed); err == nil {
-			cachedPSKSpec = &spec
+		if spec, err := quicClientHelloSpec(preset, preset.QUICPSKClientHelloID, shuffleSeed); err == nil {
+			cachedPSKSpec = spec
 		}
 	}
 	return NewQUICHostPoolWithCachedSpec(host, "", port, preset, dnsCache, cachedSpec, cachedPSKSpec, shuffleSeed)
@@ -315,16 +315,16 @@ func (p *QUICHostPool) createConn(ctx context.Context) (*QUICConn, error) {
 	// Use PSK spec ONLY when resuming a session (matches proxy path behavior)
 	if hasSession && p.cachedPSKSpec != nil && p.preset != nil && p.preset.QUICPSKClientHelloID.Client != "" {
 		// Generate fresh PSK spec for this connection
-		if spec, err := utls.UTLSIdToSpecWithSeed(p.preset.QUICPSKClientHelloID, p.shuffleSeed); err == nil {
-			selectedSpec = &spec
+		if spec, err := quicClientHelloSpec(p.preset, p.preset.QUICPSKClientHelloID, p.shuffleSeed); err == nil {
+			selectedSpec = spec
 		}
 		clientHelloID = &p.preset.QUICPSKClientHelloID
 	}
 	// Use regular spec for fresh connections
 	if selectedSpec == nil && p.cachedClientHelloSpec != nil && p.preset != nil && p.preset.QUICClientHelloID.Client != "" {
 		// Generate fresh regular spec
-		if spec, err := utls.UTLSIdToSpecWithSeed(p.preset.QUICClientHelloID, p.shuffleSeed); err == nil {
-			selectedSpec = &spec
+		if spec, err := quicClientHelloSpec(p.preset, p.preset.QUICClientHelloID, p.shuffleSeed); err == nil {
+			selectedSpec = spec
 		}
 		clientHelloID = &p.preset.QUICClientHelloID
 	}
@@ -615,15 +615,15 @@ func NewQUICManager(preset *fingerprint.Preset, dnsCache *dns.Cache) *QUICManage
 	// Generate and cache ClientHelloSpec with shuffled extensions
 	// Chrome shuffles extensions once per session, not per connection
 	if preset != nil && preset.QUICClientHelloID.Client != "" {
-		if spec, err := utls.UTLSIdToSpecWithSeed(preset.QUICClientHelloID, shuffleSeed); err == nil {
-			m.cachedSpec = &spec
+		if spec, err := quicClientHelloSpec(preset, preset.QUICClientHelloID, shuffleSeed); err == nil {
+			m.cachedSpec = spec
 		}
 	}
 
 	// Also cache PSK variant if available
 	if preset != nil && preset.QUICPSKClientHelloID.Client != "" {
-		if spec, err := utls.UTLSIdToSpecWithSeed(preset.QUICPSKClientHelloID, shuffleSeed); err == nil {
-			m.cachedPSKSpec = &spec
+		if spec, err := quicClientHelloSpec(preset, preset.QUICPSKClientHelloID, shuffleSeed); err == nil {
+			m.cachedPSKSpec = spec
 		}
 	}
 
@@ -872,4 +872,3 @@ func resolveTransportParamOrder(order string) quic.TransportParameterOrderMode {
 		return quic.TransportParameterOrderChrome
 	}
 }
-


### PR DESCRIPTION
## Summary

- generate pooled TCP ClientHello specs through the same preset-aware helper used by standalone transports
- apply independent QUIC signature-algorithm overrides in pooled QUIC specs
- cover regular, PSK, TCP, and QUIC cached specs with regression tests

## Root cause

The connection-pool paths regenerated uTLS specs directly from the ClientHello ID. That bypassed preset-level signature-algorithm overrides, so newer/custom presets could expose updated headers while retaining an older TLS fingerprint.

## Verification

- `GOTOOLCHAIN=go1.26.5 go test -race -count=10 ./pool`
- `GOTOOLCHAIN=go1.26.5 go test -race ./client ./transport`
- live direct and HTTP CONNECT observations confirm the selected preset now emits its expected stable TLS profile when consumed through the client pool