### PR TITLE
fix(transport): skip Sec-Fetch coercion for presets that send no Sec-Fetch

### DIFF
--- a/transport/preset_sec_fetch_test.go
+++ b/transport/preset_sec_fetch_test.go
@@ -1,0 +1,112 @@
+package transport
+
+import (
+	"testing"
+
+	http "github.com/sardanioss/http"
+	"github.com/sardanioss/httpcloak/fingerprint"
+)
+
+// TestPresetSendsSecFetch checks the gate that keeps the Sec-Fetch-* coercion
+// off presets describing clients that send no Sec-Fetch-* at all. Every built-in
+// must pass the gate, or applyPresetHeaders stops correcting browser headers on
+// API calls and the behavior issue #53 asked for regresses.
+func TestPresetSendsSecFetch(t *testing.T) {
+	var checked int
+	for _, name := range fingerprint.Available() {
+		p := fingerprint.GetStrict(name)
+		if p == nil {
+			continue
+		}
+		checked++
+		if !presetSendsSecFetch(p) {
+			t.Errorf("presetSendsSecFetch(%s) = false, want true for a built-in browser preset", name)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no built-in presets were checked, so this proves nothing")
+	}
+	t.Logf("checked %d built-in presets", checked)
+}
+
+// A preset whose HPACK position table declares no sec-fetch headers describes a
+// non-browser client (okhttp, curl, a native SDK). Coercing Sec-Fetch-* onto one
+// does not fix an incoherence, it invents headers the client never sends.
+func TestPresetSendsSecFetchNonBrowser(t *testing.T) {
+	tests := []struct {
+		name  string
+		order []string
+		want  bool
+	}{
+		{"okhttp-style table", []string{"authorization", "accept-language", "user-agent", "content-type", "accept-encoding"}, false},
+		{"empty table falls back to Chrome's", nil, true},
+		{"table with sec-fetch", []string{"user-agent", "sec-fetch-mode", "accept-encoding"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &fingerprint.Preset{}
+			if tt.order != nil {
+				p.H2Config = &fingerprint.H2FingerprintConfig{HPACKHeaderOrder: tt.order}
+			}
+			if got := presetSendsSecFetch(p); got != tt.want {
+				t.Errorf("presetSendsSecFetch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// The gate has to hold where it is actually used: applyPresetHeaders must leave
+// a non-browser preset's headers alone on an API-shaped request, while still
+// coercing a browser preset's.
+func TestApplyPresetHeadersSkipsSecFetchForNonBrowserPreset(t *testing.T) {
+	injected := []string{"Sec-Fetch-Mode", "Sec-Fetch-Dest", "Sec-Fetch-Site", "Accept"}
+
+	tests := []struct {
+		name       string
+		preset     *fingerprint.Preset
+		wantAbsent bool
+	}{
+		{
+			name: "non-browser preset",
+			preset: &fingerprint.Preset{
+				UserAgent: "okhttp/5.1.0",
+				H2Config: &fingerprint.H2FingerprintConfig{
+					HPACKHeaderOrder: []string{"user-agent", "content-type", "accept-encoding"},
+				},
+			},
+			wantAbsent: true,
+		},
+		{
+			name:       "browser preset",
+			preset:     fingerprint.GetStrict("chrome-146-windows"),
+			wantAbsent: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.preset == nil {
+				t.Skip("preset not registered")
+			}
+			req, err := http.NewRequest("POST", "https://example.com/api", nil)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			// An API-shaped POST, which is what sniffXHRMode classifies as XHR.
+			userHeaders := map[string][]string{"Content-Type": {"application/json"}}
+
+			applyPresetHeaders(req, tt.preset, nil, nil, false, "h2", userHeaders, false)
+
+			for _, key := range injected {
+				_, present := req.Header[key]
+				if tt.wantAbsent && present {
+					t.Errorf("%s = %q was set, want it absent for a preset that does not declare it", key, req.Header.Get(key))
+				}
+				if !tt.wantAbsent && !present {
+					t.Errorf("%s is absent, want the XHR coercion to still apply to a browser preset", key)
+				}
+			}
+		})
+	}
+}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -2198,6 +2198,36 @@ func isClientHintHeader(key string) bool {
 	return len(key) >= 7 && strings.EqualFold(key[:7], "sec-ch-")
 }
 
+// presetSendsSecFetch reports whether a preset describes a client that sends
+// Sec-Fetch-* metadata at all, by looking for those headers in the HPACK
+// position table it declares.
+//
+// The XHR coercion below rewrites Sec-Fetch-* and Accept to keep a *browser*
+// coherent on API calls. A preset for a non-browser client - okhttp, curl, a
+// native mobile SDK - has no navigation headers to correct, so running that
+// coercion on one does not fix an incoherence, it invents four headers the
+// client never sends. Presets like that are exactly what issue #76 asks for,
+// and a custom preset built through describe -> mutate -> load can already
+// produce one today.
+//
+// The position table is the right signal because it is the only one every
+// browser preset agrees on: all 79 built-ins list the Sec-Fetch-* family there,
+// none of them carries sec-fetch-mode in the emit set, and H2HeaderOrder()
+// falls back to Chrome's table when a preset declares no H2 config. So every
+// preset that behaves like a browser today keeps behaving identically, and only
+// one that deliberately declares a table without Sec-Fetch-* opts out.
+//
+// A plain prefix match is enough: HTTP/2 field names are lowercase by
+// definition (RFC 9113 8.2.1), and every built-in table follows that.
+func presetSendsSecFetch(preset *fingerprint.Preset) bool {
+	for _, key := range preset.H2HeaderOrder() {
+		if strings.HasPrefix(key, "sec-fetch-") {
+			return true
+		}
+	}
+	return false
+}
+
 func applyPresetHeaders(httpReq *http.Request, preset *fingerprint.Preset, customHeaderOrder []string, customPseudoOrder []string, tlsOnly bool, protocol string, userHeaders map[string][]string, stripClientHints bool) {
 	// In TLS-only mode, skip applying preset headers but still set header order
 	if !tlsOnly {
@@ -2226,7 +2256,11 @@ func applyPresetHeaders(httpReq *http.Request, preset *fingerprint.Preset, custo
 		// request is from method, Content-Type, Accept, and any user-supplied
 		// Sec-Fetch-* headers. WAFs like Akamai flag navigation headers on
 		// API endpoints as bot behavior.
-		if sniffXHRMode(httpReq.Method, userHeaders) {
+		//
+		// Skipped for presets that describe a client sending no Sec-Fetch-* at
+		// all; see presetSendsSecFetch for why inferring that from the preset
+		// leaves every browser preset untouched.
+		if presetSendsSecFetch(preset) && sniffXHRMode(httpReq.Method, userHeaders) {
 			// Preserve any explicitly user-supplied Sec-Fetch-Mode/Dest/Site;
 			// the sniff coercion is for "user said nothing, infer XHR" — once
 			// they pin a value (e.g. mode=no-cors, dest=image, site=same-origin)


### PR DESCRIPTION
Fixes #90. Related to #53 (which added the coercion) and #76 (which asks for the presets it misfires on).

### Problem

`applyPresetHeaders` runs the `sniffXHRMode` coercion unconditionally, so an API-shaped request always gets `Sec-Fetch-Mode` / `Dest` / `Site` set and `Accept` forced to `*/*`. That is right for a browser preset and is the behavior #53 asked for, but it also fires for a preset describing a client that sends no `Sec-Fetch-*` at all, where it adds four headers the client never sends.

#90 has a self-contained reproducer using a local HTTP/2 server.

### Change

One predicate plus one condition:

```go
if presetSendsSecFetch(preset) && sniffXHRMode(httpReq.Method, userHeaders) {
```

`presetSendsSecFetch` looks for `sec-fetch-` in the preset's HPACK position table.

### Why the position table

It is the only signal every browser preset agrees on:

- All 79 built-ins list the `Sec-Fetch-*` family in `H2HeaderOrder()`, so all 79 keep their current behavior. There is a test asserting exactly this, so a future preset that forgets the family fails loudly rather than silently losing the coercion.
- `H2HeaderOrder()` falls back to Chrome's table when a preset declares no H2 config, so presets that never configured H2 are unaffected.
- None of the 79 carries `sec-fetch-mode` in the emit set (`preset.Headers`), so gating on that instead would have disabled the coercion globally.

A plain `strings.HasPrefix` is enough, since HTTP/2 field names are lowercase by definition (RFC 9113 8.2.1) and every built-in table follows that.

Precedent for inferring browser-ness from the preset rather than adding a flag: `applyNavigationModeHeaders` in `client/client.go` already guards its client-hint block with "only if preset has them (browsers do, OkHttp doesn't)".

### Tests

`transport/preset_sec_fetch_test.go`:

- every built-in preset passes the gate
- a non-browser HPACK table fails it, an empty table passes it via the Chrome fallback, a table containing `sec-fetch-mode` passes it
- `applyPresetHeaders` itself leaves a non-browser preset alone on an API-shaped POST while still coercing a browser preset

`go test ./transport/ ./fingerprint/ ./client/ ./session/` passes.

### Note on shape

I picked inference because it needs no spec change and provably cannot regress an existing preset. If you would rather this were an explicit field in the preset spec, say so on #90 and I will rework it. Also happy to drop the tests into an existing file instead of a new one if that fits the layout better.
