### PR TITLE
Fix/deterministic header order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Headers the preset reserves no slot for now keep a stable order instead of a random one**: any header outside the impersonated browser's ordering table — custom `X-` headers, API tokens, signature headers — fell through to Go's map iteration in both the HTTP/1.1 writer and the HTTP/2 header encoder, and that iteration is deliberately randomised. The same four custom headers produced eight distinct arrangements across eight requests on HTTP/1.1, and seven across eight on HTTP/2. A header order that changes on every request is itself a strong signal, because no browser produces one, and it landed on exactly the requests most likely to be carrying something worth checking. Every header is now named up front, so nothing reaches the randomised fallback, and HTTP/1.1, HTTP/2 and HTTP/3 all agree on the result.
+
+### Changed
+
+- **A partial `SetHeaderOrder` now extends the preset's order rather than replacing it**: the list you passed used to replace the preset's ordering table wholesale, which meant every preset header you did not name joined the randomised remainder described above — so reaching for the documented ordering control made your fingerprint worse than leaving it alone. Your list is now a prefix override: the headers you name come first in the order you gave them, then the preset's own table covers everything you did not name, then anything still unplaced follows sorted by name. Passing a complete order list behaves exactly as before, and passing `nil` or an empty list still resets to the preset default.
+
 ## [1.6.8] - 2026-07-13
 
 ### Added

--- a/client/client.go
+++ b/client/client.go
@@ -1499,11 +1499,14 @@ func applyTLSOnlyHeaders(httpReq *http.Request, preset *fingerprint.Preset, req 
 	// Use H2HeaderOrder (full HPACK position table) so user-supplied headers
 	// outside the default emit set (cache-control, content-type, cookie, …)
 	// land in their real-Chrome position instead of being appended at the end.
-	if len(customHeaderOrder) > 0 {
-		httpReq.Header[http.HeaderOrderKey] = customHeaderOrder
-	} else {
-		httpReq.Header[http.HeaderOrderKey] = preset.H2HeaderOrder()
+	// CompleteHeaderOrder names whatever is still left over so it can't fall
+	// through to the encoders' randomised map iteration. User headers are
+	// already merged into httpReq.Header above, hence the nil.
+	explicitOrder := customHeaderOrder
+	if len(explicitOrder) == 0 {
+		explicitOrder = preset.H2HeaderOrder()
 	}
+	httpReq.Header[http.HeaderOrderKey] = transport.CompleteHeaderOrder(explicitOrder, preset.H2HeaderOrder(), httpReq.Header, nil)
 
 	// Set pseudo-header order from preset H2Config (explicit > heuristic > Chrome default)
 	if order := preset.H2PseudoHeaderOrder(); order != nil {
@@ -1577,12 +1580,13 @@ func applyModeHeaders(httpReq *http.Request, preset *fingerprint.Preset, req *Re
 	// Set header order for HTTP/2 and HTTP/3 fingerprinting
 	// Use H2HeaderOrder (full HPACK position table) — see the matching
 	// comment in transport.applyPresetHeaders for the rationale. Caller
-	// override still wins.
-	if len(customHeaderOrder) > 0 {
-		httpReq.Header[http.HeaderOrderKey] = customHeaderOrder
-	} else {
-		httpReq.Header[http.HeaderOrderKey] = preset.H2HeaderOrder()
+	// override still wins, completed with the preset table and then whatever
+	// is left, so nothing reaches the encoders' randomised map iteration.
+	explicitOrder := customHeaderOrder
+	if len(explicitOrder) == 0 {
+		explicitOrder = preset.H2HeaderOrder()
 	}
+	httpReq.Header[http.HeaderOrderKey] = transport.CompleteHeaderOrder(explicitOrder, preset.H2HeaderOrder(), httpReq.Header, nil)
 
 	// Set pseudo-header order from preset H2Config (explicit > heuristic > Chrome default)
 	if order := preset.H2PseudoHeaderOrder(); order != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -1502,11 +1502,7 @@ func applyTLSOnlyHeaders(httpReq *http.Request, preset *fingerprint.Preset, req 
 	// CompleteHeaderOrder names whatever is still left over so it can't fall
 	// through to the encoders' randomised map iteration. User headers are
 	// already merged into httpReq.Header above, hence the nil.
-	explicitOrder := customHeaderOrder
-	if len(explicitOrder) == 0 {
-		explicitOrder = preset.H2HeaderOrder()
-	}
-	httpReq.Header[http.HeaderOrderKey] = transport.CompleteHeaderOrder(explicitOrder, preset.H2HeaderOrder(), httpReq.Header, nil)
+	httpReq.Header[http.HeaderOrderKey] = transport.CompleteHeaderOrder(customHeaderOrder, preset.H2HeaderOrder(), httpReq.Header, nil)
 
 	// Set pseudo-header order from preset H2Config (explicit > heuristic > Chrome default)
 	if order := preset.H2PseudoHeaderOrder(); order != nil {
@@ -1582,11 +1578,7 @@ func applyModeHeaders(httpReq *http.Request, preset *fingerprint.Preset, req *Re
 	// comment in transport.applyPresetHeaders for the rationale. Caller
 	// override still wins, completed with the preset table and then whatever
 	// is left, so nothing reaches the encoders' randomised map iteration.
-	explicitOrder := customHeaderOrder
-	if len(explicitOrder) == 0 {
-		explicitOrder = preset.H2HeaderOrder()
-	}
-	httpReq.Header[http.HeaderOrderKey] = transport.CompleteHeaderOrder(explicitOrder, preset.H2HeaderOrder(), httpReq.Header, nil)
+	httpReq.Header[http.HeaderOrderKey] = transport.CompleteHeaderOrder(customHeaderOrder, preset.H2HeaderOrder(), httpReq.Header, nil)
 
 	// Set pseudo-header order from preset H2Config (explicit > heuristic > Chrome default)
 	if order := preset.H2PseudoHeaderOrder(); order != nil {

--- a/docs/docs/getting-started/common-options.md
+++ b/docs/docs/getting-started/common-options.md
@@ -215,7 +215,7 @@ var r = session.Get("https://httpbin.org/headers", headers: new() {
 </TabItem>
 </Tabs>
 
-To override the preset's header order entirely, use `SetHeaderOrder` on the session. See [Reference: Options](/reference/options) for that one.
+To lead the preset's header order with headers of your own, use `SetHeaderOrder` on the session. See [Reference: Options](/reference/options) for that one.
 
 ## Cookies
 

--- a/docs/docs/reference/options.md
+++ b/docs/docs/reference/options.md
@@ -147,7 +147,7 @@ Methods on `*Session` itself, called after `NewSession` returns. These aren't `S
 | `GetProxy() string` | Current unified or TCP proxy URL. |
 | `GetTCPProxy() string` | Current TCP proxy URL. |
 | `GetUDPProxy() string` | Current UDP proxy URL. |
-| `SetHeaderOrder(order []string)` | Override the preset's header order. Lowercase names. `nil` resets to preset default. |
+| `SetHeaderOrder(order []string)` | Override the preset's header order. Lowercase names. Treated as a prefix: named headers lead, the preset's table covers the rest, anything left over is sorted. `nil` resets to preset default. |
 | `GetHeaderOrder() []string` | Current header order, or preset default if no override. |
 | `SetSessionIdentifier(id string)` | TLS-cache key namespace. Used when a session is registered with `LocalProxy` so distributed caches isolate per-session tickets. |
 | `Warmup(ctx, url) error` | Simulates a real browser page load: fetches HTML + CSS/JS/image subresources with realistic headers, priorities, and timing. Warms TLS, cookies, ticket cache. |

--- a/docs/docs/requests-and-responses/headers.md
+++ b/docs/docs/requests-and-responses/headers.md
@@ -205,7 +205,7 @@ The reserved-slot bit is what matters. The preset's full HPACK position table, s
 
 - **Casing.** HTTP/2 and HTTP/3 are lowercase on the wire, and the preset stores everything lowercase. Pass `User-Agent: foo` and the lib normalizes it to `user-agent: foo` for H2/H3. On HTTP/1.1, casing is preserved per the request map.
 - **Removing a preset header.** Set it to `""` in your headers map and the lib won't emit it. Useful for dropping `Accept-Encoding` or similar defaults.
-- **Custom headers vs each other.** Five custom headers the preset doesn't reserve slots for all pile up at the end in the order you added them.
+- **Custom headers vs each other.** Custom headers the preset reserves no slot for are emitted after the preset's own headers, sorted by name. Sorting is deliberate rather than a fallback: the request header map has no insertion order to preserve in the first place, and ranging over it directly — which is what the library used to do — put a different order on the wire for every request, which is its own fingerprint. Sorted is also what a browser sends for `fetch()`, since the Fetch standard sorts field names before they ever reach the network stack.
 - **Cookie.** Don't set `Cookie` directly unless you've thought it through. The session jar handles it. See [Per-Request Cookies](../cookies-and-state/per-request-cookies) for the override path.
 
 ## Inspecting what went out
@@ -217,6 +217,8 @@ httpbin.org/headers is fine for "did my custom header show up?" checks, but it r
 ## Header order overrides
 
 `SetHeaderOrder(order []string)` mutates the session's emit sequence at runtime. The next request through the session uses the new order on the wire. `GetHeaderOrder()` returns whatever's currently active, custom or preset-default. Pass `nil` or an empty slice to `SetHeaderOrder` and the session falls back to the preset's baked-in order, which is what you want most of the time.
+
+The list you pass is a prefix, not a whole-cloth replacement. The headers you name lead, in the order you named them; the preset's own table then covers every header you left out; anything still unplaced follows, sorted by name. So a short list is a safe way to pin the first few positions without giving up the preset's ordering for everything else. Pass a complete list and the two later passes have nothing left to do, which is the old behaviour exactly.
 
 This is the nuclear option. The preset's order is copied from a real browser capture, and any deviation from it is new fingerprint signal that the target can hash. Use this method only when you've confirmed (with peet output, with a captured PCAP, with vendor docs) that the target runs a header-order check no shipped preset matches. That situation is rare. For nearly every site, `chrome-latest` or `firefox-148` or `safari-18` already lines up.
 
@@ -242,7 +244,7 @@ Two situations come up in practice. First is rotating between known-good orders 
 
 Heads up on persistence: the custom order is held in memory on the transport. `Save` / `LoadSession` round-trip the preset, cookies, TLS tickets, and ECH configs, but they don't currently serialize a custom header order. If you set a custom order, save the session, then load it, the session comes back on the preset's default. Re-apply your `SetHeaderOrder` call after `LoadSession` if you need the override to stick.
 
-Custom orders don't disable the preset's HPACK position table for situational headers. The preset reserves slots for headers Chrome only emits some of the time (`cache-control`, `content-type`, `content-length`, `cookie`, `origin`, `referer`), and those slots stay live on top of whatever base order you set. So a custom order of `[user-agent, accept, x-my-header]` plus a POST with `Content-Type: application/json` and a `Cookie` from the jar still places `content-type` and `cookie` at the offsets the preset reserves for them. The custom order replaces the default base sequence, not the slot machinery underneath.
+Custom orders don't disable the preset's HPACK position table for situational headers. The preset reserves slots for headers Chrome only emits some of the time (`cache-control`, `content-type`, `content-length`, `cookie`, `origin`, `referer`), and those slots stay live on top of whatever base order you set. So a custom order of `[user-agent, accept, x-my-header]` plus a POST with `Content-Type: application/json` and a `Cookie` from the jar still places `content-type` and `cookie` at the offsets the preset reserves for them, behind the three headers you named. Your list sets the leading sequence; the slot machinery underneath keeps running for everything else.
 
 <Tabs groupId="lang">
 <TabItem value="go" label="Go">

--- a/httpcloak.go
+++ b/httpcloak.go
@@ -1033,6 +1033,11 @@ func (s *Session) GetUDPProxy() string {
 // SetHeaderOrder sets a custom header order for all requests.
 // Pass nil or empty slice to reset to preset's default order.
 // Order should contain lowercase header names.
+//
+// The list is a prefix, not a replacement: the headers named here lead in the
+// order given, the preset's own table then covers whatever they did not name,
+// and anything still unplaced follows sorted by name. A partial list therefore
+// costs nothing for the headers it leaves out.
 func (s *Session) SetHeaderOrder(order []string) {
 	s.inner.SetHeaderOrder(order)
 }

--- a/transport/header_order_test.go
+++ b/transport/header_order_test.go
@@ -1,0 +1,129 @@
+package transport
+
+import (
+	"strings"
+	"testing"
+
+	http "github.com/sardanioss/http"
+)
+
+// Headers that a preset does not reserve a slot for used to fall through to Go
+// map iteration in both the HTTP/1.1 writer and the HPACK encoder, which
+// randomises its order on every range. That produced a different header order
+// on every request — a fingerprint no browser emits. These tests pin the
+// contract that CompleteHeaderOrder names every header exactly once, in a
+// stable order.
+
+func TestCompleteHeaderOrder_UnreservedHeadersAreSortedNotRandom(t *testing.T) {
+	presetOrder := []string{"user-agent", "accept", "accept-encoding"}
+	header := http.Header{
+		"User-Agent": {"chrome"},
+		"Accept":     {"*/*"},
+		"X-Delta":    {"4"},
+		"X-Bravo":    {"2"},
+		"X-Alpha":    {"1"},
+		"X-Charlie":  {"3"},
+	}
+
+	got := CompleteHeaderOrder(presetOrder, presetOrder, header, nil)
+	want := []string{
+		"user-agent", "accept", "accept-encoding",
+		"x-alpha", "x-bravo", "x-charlie", "x-delta",
+	}
+	assertOrder(t, got, want)
+}
+
+func TestCompleteHeaderOrder_IsStableAcrossCalls(t *testing.T) {
+	presetOrder := []string{"user-agent", "accept"}
+	header := http.Header{
+		"User-Agent": {"chrome"},
+		"X-Delta":    {"4"},
+		"X-Bravo":    {"2"},
+		"X-Alpha":    {"1"},
+		"X-Charlie":  {"3"},
+		"X-Echo":     {"5"},
+		"X-Foxtrot":  {"6"},
+	}
+
+	first := strings.Join(CompleteHeaderOrder(presetOrder, presetOrder, header, nil), ",")
+	for i := 0; i < 200; i++ {
+		got := strings.Join(CompleteHeaderOrder(presetOrder, presetOrder, header, nil), ",")
+		if got != first {
+			t.Fatalf("order varied between calls:\n first: %s\n call %d: %s", first, i, got)
+		}
+	}
+}
+
+// A partial SetHeaderOrder used to place the named headers and then scramble
+// every preset header it did not name, so reaching for the documented ordering
+// control made the fingerprint worse. The named list is now a prefix override:
+// named first, then the preset's own table, then the rest.
+func TestCompleteHeaderOrder_PartialCustomOrderKeepsPresetTable(t *testing.T) {
+	presetOrder := []string{"sec-ch-ua", "user-agent", "accept", "accept-encoding", "accept-language"}
+	custom := []string{"x-delta", "user-agent", "accept"}
+	header := http.Header{
+		"Sec-Ch-Ua":       {"chrome"},
+		"User-Agent":      {"chrome"},
+		"Accept":          {"*/*"},
+		"Accept-Encoding": {"gzip"},
+		"Accept-Language": {"en"},
+		"X-Delta":         {"4"},
+		"X-Alpha":         {"1"},
+	}
+
+	got := CompleteHeaderOrder(custom, presetOrder, header, nil)
+	want := []string{
+		"x-delta", "user-agent", "accept", // caller's list, in the caller's order
+		"sec-ch-ua", "accept-encoding", "accept-language", // preset table, preset order
+		"x-alpha", // still unplaced, sorted
+	}
+	assertOrder(t, got, want)
+}
+
+// The ordering keys are internal control entries. Leaking one onto the wire
+// would be a header no browser sends.
+func TestCompleteHeaderOrder_ExcludesOrderingKeys(t *testing.T) {
+	header := http.Header{
+		"Accept":             {"*/*"},
+		http.HeaderOrderKey:  {"accept"},
+		http.PHeaderOrderKey: {":method"},
+		"X-Alpha":            {"1"},
+	}
+
+	for _, name := range CompleteHeaderOrder([]string{"accept"}, []string{"accept"}, header, nil) {
+		if strings.EqualFold(name, http.HeaderOrderKey) || strings.EqualFold(name, http.PHeaderOrderKey) {
+			t.Errorf("ordering key %q leaked into the header order", name)
+		}
+	}
+}
+
+func TestCompleteHeaderOrder_MergesUserHeadersAndDeduplicates(t *testing.T) {
+	presetOrder := []string{"user-agent"}
+	header := http.Header{"User-Agent": {"chrome"}, "X-Bravo": {"2"}}
+	// Same header in both sources, differing case; must appear exactly once.
+	userHeaders := map[string][]string{"X-BRAVO": {"2"}, "x-alpha": {"1"}}
+
+	got := CompleteHeaderOrder(presetOrder, presetOrder, header, userHeaders)
+	assertOrder(t, got, []string{"user-agent", "x-alpha", "x-bravo"})
+
+	seen := map[string]int{}
+	for _, name := range got {
+		seen[name]++
+		if name != strings.ToLower(name) {
+			t.Errorf("header order entry %q is not lowercased", name)
+		}
+	}
+	for name, n := range seen {
+		if n > 1 {
+			t.Errorf("header %q appears %d times in the order", name, n)
+		}
+	}
+}
+
+func assertOrder(t *testing.T, got, want []string) {
+	t.Helper()
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("header order mismatch\n got: %s\nwant: %s",
+			strings.Join(got, " → "), strings.Join(want, " → "))
+	}
+}

--- a/transport/header_order_test.go
+++ b/transport/header_order_test.go
@@ -1,6 +1,8 @@
 package transport
 
 import (
+	"bufio"
+	"bytes"
 	"strings"
 	"testing"
 
@@ -126,4 +128,87 @@ func assertOrder(t *testing.T, got, want []string) {
 		t.Errorf("header order mismatch\n got: %s\nwant: %s",
 			strings.Join(got, " → "), strings.Join(want, " → "))
 	}
+}
+
+// writeH1Order runs the HTTP/1.1 header writer over req and returns the header
+// names in the order they hit the wire, lowercased. The writer does not touch
+// its receiver, so a zero-value transport is enough and the test stays off the
+// network.
+func writeH1Order(t *testing.T, req *http.Request) []string {
+	t.Helper()
+	var buf bytes.Buffer
+	bw := bufio.NewWriter(&buf)
+	(&HTTP1Transport{}).writeHeadersInOrder(bw, req, false)
+	if err := bw.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	var names []string
+	for _, line := range strings.Split(buf.String(), "\r\n") {
+		if line == "" {
+			continue
+		}
+		name, _, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		names = append(names, strings.ToLower(strings.TrimSpace(name)))
+	}
+	return names
+}
+
+// The HTTP/1.1 writer's remainder loop is the fallback for any request that
+// reaches it without a complete order list. It used to range over req.Header
+// directly, and Go randomises map iteration on every range, so it put a
+// different header order on the wire for each request. applyPresetHeaders now
+// names every header up front and normally leaves this loop empty — this pins
+// the fallback, so dropping the sort in writeHeadersInOrder cannot quietly
+// restore the per-request randomisation.
+func TestWriteHeadersInOrder_RemainderIsSortedNotRandom(t *testing.T) {
+	newReq := func() *http.Request {
+		return &http.Request{
+			Method: "GET",
+			Header: http.Header{
+				"X-Delta":   {"4"},
+				"X-Bravo":   {"2"},
+				"X-Alpha":   {"1"},
+				"X-Charlie": {"3"},
+				"X-Echo":    {"5"},
+				"X-Foxtrot": {"6"},
+			},
+		}
+	}
+
+	want := []string{"x-alpha", "x-bravo", "x-charlie", "x-delta", "x-echo", "x-foxtrot"}
+	first := writeH1Order(t, newReq())
+	assertOrder(t, first, want)
+
+	// Randomised map iteration only shows up across repeated ranges.
+	for i := 0; i < 200; i++ {
+		got := writeH1Order(t, newReq())
+		if strings.Join(got, ",") != strings.Join(first, ",") {
+			t.Fatalf("h1 wire order varied between requests:\n first: %s\n run %d: %s",
+				strings.Join(first, " → "), i, strings.Join(got, " → "))
+		}
+	}
+}
+
+// The two halves of the fix have to compose: CompleteHeaderOrder names every
+// header, so by the time the writer runs its remainder loop there is nothing
+// left for it to iterate over, and the wire order is exactly the order list
+// (minus the names the request does not actually carry).
+func TestWriteHeadersInOrder_CompleteOrderLeavesNoRemainder(t *testing.T) {
+	presetOrder := []string{"user-agent", "accept", "accept-encoding"}
+	header := http.Header{
+		"User-Agent": {"chrome"},
+		"Accept":     {"*/*"},
+		"X-Delta":    {"4"},
+		"X-Alpha":    {"1"},
+	}
+	header[http.HeaderOrderKey] = CompleteHeaderOrder(nil, presetOrder, header, nil)
+
+	// accept-encoding is reserved by the preset but absent from the request, so
+	// it is named in the order list and skipped on the wire.
+	assertOrder(t, writeH1Order(t, &http.Request{Method: "GET", Header: header}),
+		[]string{"user-agent", "accept", "x-alpha", "x-delta"})
 }

--- a/transport/http1_transport.go
+++ b/transport/http1_transport.go
@@ -11,6 +11,7 @@ import (
 	http "github.com/sardanioss/http"
 	"net/textproto"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -1149,12 +1150,23 @@ func (t *HTTP1Transport) writeHeadersInOrder(w *bufio.Writer, req *http.Request,
 		}
 	}
 
-	// Write remaining headers (not in specified order)
-	for key, values := range req.Header {
-		// Key from map iteration is already canonical
-		if written[key] {
-			continue
+	// Write remaining headers (not in specified order). Sorted rather than
+	// ranged over directly: Go randomises map iteration per range, so an
+	// unsorted remainder puts a different header order on the wire for every
+	// request, which is itself a fingerprint. applyPresetHeaders normally names
+	// every header up front and leaves this loop empty; the sort is what keeps
+	// the fallback stable when it does not.
+	remaining := make([]string, 0, len(req.Header))
+	for key := range req.Header {
+		if !written[key] {
+			remaining = append(remaining, key)
 		}
+	}
+	sort.Strings(remaining)
+
+	for _, key := range remaining {
+		// Key from map iteration is already canonical
+		values := req.Header[key]
 		// Skip Host (already written) and certain headers
 		if strings.EqualFold(key, "Host") {
 			continue

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -860,6 +860,9 @@ func (t *Transport) SetECHConfigDomain(domain string) {
 // SetHeaderOrder sets a custom header order for all requests.
 // Pass nil or empty slice to reset to preset's default order.
 // Order should contain lowercase header names.
+//
+// The list is a prefix, not a replacement — see CompleteHeaderOrder, which does
+// the assembly.
 func (t *Transport) SetHeaderOrder(order []string) {
 	t.customHeaderOrderMu.Lock()
 	defer t.customHeaderOrderMu.Unlock()
@@ -2203,11 +2206,13 @@ func isClientHintHeader(key string) bool {
 // request carries, so none is left to an encoder's map-iteration fallback.
 //
 // The list is assembled in three passes: explicitOrder (a caller's
-// SetHeaderOrder, or presetOrder when there is none); then presetOrder, so a
-// partial custom list does not cost the caller the preset's ordering for the
-// headers they did not name; then everything still unplaced, sorted by name.
-// Names are lowercased and de-duplicated. userHeaders may be nil when the
-// caller has already merged them into header.
+// SetHeaderOrder, empty when there is none); then presetOrder, so a partial
+// custom list does not cost the caller the preset's ordering for the headers
+// they did not name; then everything still unplaced, sorted by name. An empty
+// explicitOrder needs no special case — pass one falls through and pass two
+// lays down the preset table on its own. Names are lowercased and
+// de-duplicated. userHeaders may be nil when the caller has already merged
+// them into header.
 //
 // Both remainders were previously emitted in Go map order, which is randomised
 // on every range. A header order that differs per request is itself a
@@ -2384,11 +2389,7 @@ func applyPresetHeaders(httpReq *http.Request, preset *fingerprint.Preset, custo
 	// fingerprinting bug — when callers added cache-control/content-type/
 	// cookie, the fork couldn't slot them and appended them after `priority`
 	// instead of placing them where real Chrome does.
-	explicitOrder := customHeaderOrder
-	if len(explicitOrder) == 0 {
-		explicitOrder = preset.H2HeaderOrder()
-	}
-	httpReq.Header[http.HeaderOrderKey] = CompleteHeaderOrder(explicitOrder, preset.H2HeaderOrder(), httpReq.Header, userHeaders)
+	httpReq.Header[http.HeaderOrderKey] = CompleteHeaderOrder(customHeaderOrder, preset.H2HeaderOrder(), httpReq.Header, userHeaders)
 
 	// Set pseudo-header order: custom (Akamai) > preset H2Config > heuristic
 	if len(customPseudoOrder) > 0 {

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -10,6 +10,7 @@ import (
 	http "github.com/sardanioss/http"
 	"io"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -2198,6 +2199,64 @@ func isClientHintHeader(key string) bool {
 	return len(key) >= 7 && strings.EqualFold(key[:7], "sec-ch-")
 }
 
+// CompleteHeaderOrder builds a header-order list that names every header the
+// request carries, so none is left to an encoder's map-iteration fallback.
+//
+// The list is assembled in three passes: explicitOrder (a caller's
+// SetHeaderOrder, or presetOrder when there is none); then presetOrder, so a
+// partial custom list does not cost the caller the preset's ordering for the
+// headers they did not name; then everything still unplaced, sorted by name.
+// Names are lowercased and de-duplicated. userHeaders may be nil when the
+// caller has already merged them into header.
+//
+// Both remainders were previously emitted in Go map order, which is randomised
+// on every range. A header order that differs per request is itself a
+// fingerprint, and a strong one — no browser produces one. Sorted is not what a
+// browser sends either, but it is stable, which is the detectable part.
+func CompleteHeaderOrder(explicitOrder, presetOrder []string, header http.Header, userHeaders map[string][]string) []string {
+	seen := make(map[string]bool, len(explicitOrder)+len(presetOrder)+len(header)+len(userHeaders))
+	order := make([]string, 0, len(explicitOrder)+len(presetOrder)+len(header)+len(userHeaders))
+
+	place := func(name string) {
+		lower := strings.ToLower(name)
+		if lower == "" || seen[lower] {
+			return
+		}
+		seen[lower] = true
+		order = append(order, lower)
+	}
+	for _, name := range explicitOrder {
+		place(name)
+	}
+	for _, name := range presetOrder {
+		place(name)
+	}
+
+	rest := make([]string, 0, len(header)+len(userHeaders))
+	collect := func(name string) {
+		// The ordering keys are internal control entries, not headers, and must
+		// never reach the wire.
+		if strings.EqualFold(name, http.HeaderOrderKey) || strings.EqualFold(name, http.PHeaderOrderKey) {
+			return
+		}
+		lower := strings.ToLower(name)
+		if lower == "" || seen[lower] {
+			return
+		}
+		seen[lower] = true
+		rest = append(rest, lower)
+	}
+	for name := range header {
+		collect(name)
+	}
+	for name := range userHeaders {
+		collect(name)
+	}
+	sort.Strings(rest)
+
+	return append(order, rest...)
+}
+
 func applyPresetHeaders(httpReq *http.Request, preset *fingerprint.Preset, customHeaderOrder []string, customPseudoOrder []string, tlsOnly bool, protocol string, userHeaders map[string][]string, stripClientHints bool) {
 	// In TLS-only mode, skip applying preset headers but still set header order
 	if !tlsOnly {
@@ -2325,11 +2384,11 @@ func applyPresetHeaders(httpReq *http.Request, preset *fingerprint.Preset, custo
 	// fingerprinting bug — when callers added cache-control/content-type/
 	// cookie, the fork couldn't slot them and appended them after `priority`
 	// instead of placing them where real Chrome does.
-	if len(customHeaderOrder) > 0 {
-		httpReq.Header[http.HeaderOrderKey] = customHeaderOrder
-	} else {
-		httpReq.Header[http.HeaderOrderKey] = preset.H2HeaderOrder()
+	explicitOrder := customHeaderOrder
+	if len(explicitOrder) == 0 {
+		explicitOrder = preset.H2HeaderOrder()
 	}
+	httpReq.Header[http.HeaderOrderKey] = CompleteHeaderOrder(explicitOrder, preset.H2HeaderOrder(), httpReq.Header, userHeaders)
 
 	// Set pseudo-header order: custom (Akamai) > preset H2Config > heuristic
 	if len(customPseudoOrder) > 0 {


### PR DESCRIPTION
### Problem

Headers a preset reserves no slot for — custom `X-` headers, API tokens, signature headers — fell through to Go map iteration in both the HTTP/1.1 writer and the HPACK encoder. That iteration is randomised, so the same four custom headers produced 8 distinct arrangements across 8 requests on h1, and 7 across 8 on h2.

A per-request-random header order is itself a strong fingerprint — no browser produces one — and it landed on exactly the requests most likely to be carrying something worth checking.

A partial `SetHeaderOrder` was worse still: the supplied list replaced the preset's table wholesale, so every preset header the caller did not name joined the same random remainder. Reaching for the documented ordering control made the fingerprint worse than leaving it alone.

### Fix

`CompleteHeaderOrder` names every header up front, in three passes — the caller's explicit list, then the preset's reserved table for whatever that list did not name, then everything still unplaced, sorted. The encoders' remainder loops have nothing left to iterate over.

That fixes h1 and h2 from one place without touching the vendored HPACK encoder in `sardanioss/net`. HTTP/3 already sorted its remainder, so all three protocols now agree. The h1 remainder loop is sorted too, as a fallback for any path that does not set an order list.

### Behaviour change

A partial `SetHeaderOrder` is now a prefix override rather than a wholesale replacement: named headers lead in the order given, the preset's table covers whatever they left out, anything still unplaced follows sorted. A complete list behaves exactly as before, and `nil`/empty still resets to the preset default. CHANGELOG and docs are updated, including one line that had documented the randomness as if it were intentional ("pile up at the end in the order you added them" — a Go map has no insertion order to preserve).

Sorting is not merely a stable fallback: it is what a browser sends for `fetch()`, since the Fetch standard sorts field names before they reach the network stack.

### Tests

Unit tests for `CompleteHeaderOrder` (ordering, stability across 200 calls, partial-list semantics, ordering-key exclusion, dedup and casing) and for the HTTP/1.1 writer's sorted remainder. The writer tests were confirmed to fail when the sort is removed, so they genuinely guard it.

Verified end-to-end against raw h1/h2 wire captures: correct positions, no `host` or `connection` leaking onto the h2 wire, and no duplicates.