### PR TITLE
Fix/h1 context cancellation

### DIFF
--- a/transport/context_cancel_test.go
+++ b/transport/context_cancel_test.go
@@ -1,0 +1,120 @@
+package transport
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+// An HTTP/1.1 exchange blocks in a socket read that only a deadline can
+// interrupt, so without a watchdog a cancelled context is invisible to it and
+// the caller waits out the full response timeout instead.
+func TestWatchContext_CancelUnblocksBlockedRead(t *testing.T) {
+	local, remote := net.Pipe()
+	defer local.Close()
+	defer remote.Close()
+
+	conn := &http1Conn{conn: local}
+	ctx, cancel := context.WithCancel(context.Background())
+	stop := watchContext(ctx, conn)
+	defer stop()
+
+	readErr := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 1)
+		_, err := local.Read(buf) // nothing is ever written
+		readErr <- err
+	}()
+
+	select {
+	case err := <-readErr:
+		t.Fatalf("read returned before cancellation: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case err := <-readErr:
+		if err == nil {
+			t.Fatal("expected the interrupted read to fail")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelling the context did not unblock the read")
+	}
+
+	if !conn.poisoned.Load() {
+		t.Error("connection not marked poisoned; it would go back to the pool mid-response")
+	}
+}
+
+// doHTTP1 cancels its derived context on return, microseconds after the body is
+// read. The watchdog must not act on that: poisoning a connection that has just
+// been returned to the pool would silently destroy keep-alive.
+func TestWatchContext_DoesNotPoisonAfterExchangeCompletes(t *testing.T) {
+	local, remote := net.Pipe()
+	defer local.Close()
+	defer remote.Close()
+
+	conn := &http1Conn{conn: local}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	stop := watchContext(ctx, conn)
+	stop()   // exchange finished, connection headed for the pool
+	cancel() // doHTTP1's deferred cancel fires right behind it
+
+	time.Sleep(50 * time.Millisecond)
+	if conn.poisoned.Load() {
+		t.Error("watchdog poisoned a connection whose exchange had already completed")
+	}
+}
+
+// A context with no Done channel needs no watchdog goroutine at all.
+func TestWatchContext_BackgroundContextIsANoop(t *testing.T) {
+	conn := &http1Conn{}
+	stop := watchContext(context.Background(), conn)
+	stop()
+	stop() // must be idempotent
+	if conn.poisoned.Load() {
+		t.Error("background context poisoned the connection")
+	}
+}
+
+func TestContextError(t *testing.T) {
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	expired, cancelExpired := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancelExpired()
+
+	future, cancelFuture := context.WithTimeout(context.Background(), time.Hour)
+	defer cancelFuture()
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		want error
+	}{
+		{"live background context", context.Background(), nil},
+		{"deadline still in the future", future, nil},
+		{"cancelled", cancelled, context.Canceled},
+		{"deadline passed", expired, context.DeadlineExceeded},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := contextError(tc.ctx)
+			if tc.want == nil {
+				if got != nil {
+					t.Errorf("contextError() = %v, want nil", got)
+				}
+				return
+			}
+			if !errors.Is(got, tc.want) {
+				t.Errorf("contextError() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/transport/context_cancel_test.go
+++ b/transport/context_cancel_test.go
@@ -1,11 +1,17 @@
 package transport
 
 import (
+	"bufio"
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"testing"
 	"time"
+
+	http "github.com/sardanioss/http"
+	"github.com/sardanioss/httpcloak/dns"
+	"github.com/sardanioss/httpcloak/fingerprint"
 )
 
 // An HTTP/1.1 exchange blocks in a socket read that only a deadline can
@@ -79,6 +85,218 @@ func TestWatchContext_BackgroundContextIsANoop(t *testing.T) {
 	stop() // must be idempotent
 	if conn.poisoned.Load() {
 		t.Error("background context poisoned the connection")
+	}
+}
+
+// A flagged-but-live connection is a landmine: any ordering accident that gets
+// it past the poisoned check hands the next request a socket carrying a
+// deadline in the past. poison therefore retires the socket outright.
+func TestPoison_RetiresTheSocket(t *testing.T) {
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		c, err := ln.Accept()
+		if err == nil {
+			defer c.Close()
+			time.Sleep(2 * time.Second)
+		}
+	}()
+
+	c, err := net.Dial("tcp4", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	conn := &http1Conn{conn: c}
+	conn.poison()
+
+	if !conn.poisoned.Load() {
+		t.Error("poison did not flag the connection")
+	}
+	// handleClose clears the deadline before pooling, and the next request arms
+	// its own. Neither may resurrect the socket. A live socket would block here
+	// and come back with a timeout; a retired one fails at once.
+	c.SetDeadline(time.Now().Add(500 * time.Millisecond))
+	_, err = c.Read(make([]byte, 1))
+	if err == nil {
+		t.Fatal("socket still readable after poison")
+	}
+	var nerr net.Error
+	if errors.As(err, &nerr) && nerr.Timeout() {
+		t.Errorf("socket still open after poison (read merely timed out: %v): a stale watchdog "+
+			"could hand a live connection to the pool", err)
+	}
+}
+
+// handleClose reads conn.poisoned the instant stopWatch() returns, and pools the
+// connection on the strength of it. That read is only trustworthy if stopWatch
+// has waited for the watchdog to make up its mind; a flag the watchdog may not
+// have acted on yet lets a poisoned connection race into the pool.
+func TestWatchContext_StopSettlesTheWatchdog(t *testing.T) {
+	const iters = 1000
+	for i := 0; i < iters; i++ {
+		local, remote := net.Pipe()
+		conn := &http1Conn{conn: local}
+		ctx, cancel := context.WithCancel(context.Background())
+
+		stop := watchContext(ctx, conn)
+		go cancel()
+		stop()
+
+		// This is exactly the check handleClose performs before pooling.
+		decided := conn.poisoned.Load()
+		time.Sleep(20 * time.Microsecond)
+		if got := conn.poisoned.Load(); got != decided {
+			t.Fatalf("iteration %d: poisoned flipped from %v to %v after stop() returned; "+
+				"handleClose would already have pooled the connection", i, decided, got)
+		}
+
+		cancel()
+		local.Close()
+		remote.Close()
+	}
+}
+
+func TestTranslateBodyError(t *testing.T) {
+	netErr := errors.New("read tcp 1.2.3.4:80: i/o timeout")
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	expired, cancelExpired := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancelExpired()
+
+	live, cancelLive := context.WithTimeout(context.Background(), time.Hour)
+	defer cancelLive()
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		want error
+	}{
+		{"cancelled context claims the read error", cancelled, context.Canceled},
+		{"expired deadline claims the read error", expired, context.DeadlineExceeded},
+		{"live context leaves a genuine network error alone", live, netErr},
+		{"no context leaves the error alone", nil, netErr},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := translateBodyError(tc.ctx, netErr)
+			if !errors.Is(got, tc.want) {
+				t.Errorf("translateBodyError() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// stalledBodyServer answers with headers and a sliver of body, then goes quiet
+// forever — the shape that makes a caller cancel mid-download.
+func stalledBodyServer(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				br := bufio.NewReader(c)
+				for {
+					line, err := br.ReadString('\n')
+					if err != nil {
+						return
+					}
+					if line == "\r\n" || line == "\n" {
+						break
+					}
+				}
+				fmt.Fprint(c, "HTTP/1.1 200 OK\r\nContent-Length: 10000000\r\n\r\n")
+				c.Write(make([]byte, 4096))
+				c.Read(make([]byte, 1)) // hold the connection until the client leaves
+			}(c)
+		}
+	}()
+	return "http://" + ln.Addr().String() + "/"
+}
+
+// The point of the watchdog is that a caller can tell their own cancellation
+// from a network fault. Interrupting the header wait was never the hard part —
+// cancelling mid-download is the common case, and the raw socket error the
+// watchdog produces there ("i/o timeout") is indistinguishable from a genuine
+// fault, so callers retry a request the user deliberately abandoned.
+func TestHTTP1_BodyReadReportsContextError(t *testing.T) {
+	url := stalledBodyServer(t)
+
+	tests := []struct {
+		name    string
+		newCtx  func() (context.Context, context.CancelFunc)
+		want    error
+		trigger bool // cancel explicitly after the body starts
+	}{
+		{
+			name:    "cancelled during the body read",
+			newCtx:  func() (context.Context, context.CancelFunc) { return context.WithCancel(context.Background()) },
+			want:    context.Canceled,
+			trigger: true,
+		},
+		{
+			name: "deadline expires during the body read",
+			newCtx: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), 200*time.Millisecond)
+			},
+			want: context.DeadlineExceeded,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := NewHTTP1Transport(fingerprint.Chrome146(), dns.NewCache())
+			defer tr.Close()
+
+			ctx, cancel := tc.newCtx()
+			defer cancel()
+
+			req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp, err := tr.RoundTrip(req)
+			if err != nil {
+				t.Fatalf("headers should have arrived: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if tc.trigger {
+				go func() { time.Sleep(200 * time.Millisecond); cancel() }()
+			}
+
+			var readErr error
+			buf := make([]byte, 32*1024)
+			deadline := time.Now().Add(5 * time.Second)
+			for readErr == nil {
+				_, readErr = resp.Body.Read(buf)
+				if time.Now().After(deadline) {
+					t.Fatal("body read never unblocked")
+				}
+			}
+
+			if !errors.Is(readErr, tc.want) {
+				t.Errorf("body read error = %v; errors.Is(err, %v) = false, so a caller cannot "+
+					"tell their own cancellation from a network fault", readErr, tc.want)
+			}
+		})
 	}
 }
 

--- a/transport/http1_transport.go
+++ b/transport/http1_transport.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/sardanioss/httpcloak/dns"
@@ -63,6 +64,83 @@ type http1Conn struct {
 	useCount   int64
 	mu         sync.Mutex
 	closed     bool
+	// poisoned marks a connection interrupted mid-exchange by a cancelled
+	// request context. Atomic rather than guarded by mu: it is set from the
+	// context watchdog while doRequest holds mu for the whole exchange.
+	poisoned atomic.Bool
+}
+
+// poison unblocks whatever this connection is currently blocked on and marks it
+// unfit for reuse.
+//
+// It deliberately touches only the socket deadline and an atomic flag. doRequest
+// holds c.mu for the full duration of an exchange and close() also takes c.mu,
+// so a watchdog that tried to close the connection would deadlock against the
+// very exchange it is trying to interrupt. Setting a deadline in the past makes
+// any in-flight Read or Write return immediately, and net.Conn deadlines are
+// safe to set from another goroutine.
+func (c *http1Conn) poison() {
+	c.poisoned.Store(true)
+	if c.conn != nil {
+		c.conn.SetDeadline(time.Now())
+	}
+}
+
+// contextError reports why the request context ended, or nil if it has not.
+//
+// It also claims a socket deadline that fired at or past the context's own
+// deadline. doRequest arms the socket deadline from the context deadline, so
+// the two expire together and the socket read typically loses the race by
+// microseconds — reporting the raw "i/o timeout" there would hand the caller an
+// opaque network error for what is really their own deadline, and defeat an
+// errors.Is(err, context.DeadlineExceeded) check.
+func contextError(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if deadline, ok := ctx.Deadline(); ok && !time.Now().Before(deadline) {
+		return context.DeadlineExceeded
+	}
+	return nil
+}
+
+// watchContext makes a cancelled context interrupt an in-flight HTTP/1.1
+// exchange, and returns a function that stops watching.
+//
+// HTTP/2 and HTTP/3 select on ctx.Done() in their own request paths, but the
+// HTTP/1.1 exchange blocks in a socket read that only a deadline can interrupt.
+// Without this, a cancelled context is invisible: doRequest converts the
+// context's *deadline* into a socket deadline once, at the start, and then never
+// looks at the context again. A caller who cancels therefore waits out the full
+// response timeout — up to 30s past the moment they gave up.
+func watchContext(ctx context.Context, conn *http1Conn) func() {
+	done := ctx.Done()
+	if done == nil {
+		return func() {}
+	}
+	stop := make(chan struct{})
+	var finished atomic.Bool
+	go func() {
+		select {
+		case <-done:
+			// Both channels can be closed by the time this goroutine runs: the
+			// exchange finishes, then doHTTP1's deferred cancel fires micro-
+			// seconds later. A select with two ready cases picks at random, so
+			// without this guard the watchdog could poison a healthy connection
+			// just as it returned to the pool, silently killing keep-alive.
+			if !finished.Load() {
+				conn.poison()
+			}
+		case <-stop:
+		}
+	}()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			finished.Store(true)
+			close(stop)
+		})
+	}
 }
 
 // NewHTTP1Transport creates a new HTTP/1.1 transport with uTLS
@@ -180,21 +258,29 @@ func (t *HTTP1Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Try to get an idle connection
 	conn, err := t.getIdleConn(key)
 	if err == nil && conn != nil {
+		stopWatch := watchContext(req.Context(), conn)
 		resp, err := t.doRequest(conn, req)
-		if err == nil {
+		if err == nil && req.Context().Err() == nil {
 			// Wrap the body to handle connection lifecycle
 			// Connection will be returned to pool or closed when body is fully read
 			resp.Body = &pooledBodyWrapper{
-				body:        resp.Body,
-				conn:        conn,
-				key:         key,
-				transport:   t,
-				keepAlive:   t.shouldKeepAlive(req, resp),
+				body:      resp.Body,
+				conn:      conn,
+				key:       key,
+				transport: t,
+				keepAlive: t.shouldKeepAlive(req, resp),
+				stopWatch: stopWatch,
 			}
 			return resp, nil
 		}
 		// Connection failed, close it and try new one
+		stopWatch()
 		conn.close()
+		// A cancelled context is the caller giving up, not a bad connection:
+		// report it as such instead of retrying on a fresh socket.
+		if ctxErr := contextError(req.Context()); ctxErr != nil {
+			return nil, ctxErr
+		}
 	}
 
 	// Create new connection (pass request host for SNI, connectHost used internally for DNS)
@@ -203,19 +289,25 @@ func (t *HTTP1Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
+	stopWatch := watchContext(req.Context(), conn)
 	resp, err := t.doRequest(conn, req)
-	if err != nil {
+	if err != nil || req.Context().Err() != nil {
+		stopWatch()
 		conn.close()
+		if ctxErr := contextError(req.Context()); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return nil, WrapError("request", host, port, "h1", err)
 	}
 
 	// Wrap the body to handle connection lifecycle
 	resp.Body = &pooledBodyWrapper{
-		body:        resp.Body,
-		conn:        conn,
-		key:         key,
-		transport:   t,
-		keepAlive:   t.shouldKeepAlive(req, resp),
+		body:      resp.Body,
+		conn:      conn,
+		key:       key,
+		transport: t,
+		keepAlive: t.shouldKeepAlive(req, resp),
+		stopWatch: stopWatch,
 	}
 
 	return resp, nil
@@ -252,16 +344,22 @@ func (t *HTTP1Transport) RoundTripWithTLSConn(req *http.Request, tlsConn *utls.U
 		bw:         bufio.NewWriterSize(tlsConn, 256*1024), // 256KB write buffer
 	}
 
+	stopWatch := watchContext(req.Context(), conn)
 	resp, err := t.doRequest(conn, req)
-	if err != nil {
+	if err != nil || req.Context().Err() != nil {
+		stopWatch()
 		conn.close()
+		if ctxErr := contextError(req.Context()); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return nil, WrapError("request", host, port, "h1", err)
 	}
 
 	// Wrap the body to close connection when done (not pooled since it came from H2 attempt)
 	resp.Body = &streamBodyWrapper{
-		body: resp.Body,
-		conn: conn,
+		body:      resp.Body,
+		conn:      conn,
+		stopWatch: stopWatch,
 	}
 
 	return resp, nil
@@ -276,6 +374,9 @@ type pooledBodyWrapper struct {
 	transport *HTTP1Transport
 	keepAlive bool
 	once      sync.Once
+	// stopWatch ends the request's context watchdog. It stays armed until the
+	// body is done, so a cancellation during the body read unblocks too.
+	stopWatch func()
 }
 
 func (w *pooledBodyWrapper) Read(p []byte) (n int, err error) {
@@ -294,31 +395,45 @@ func (w *pooledBodyWrapper) Close() error {
 	if err != nil {
 		// Body drain failed (e.g., deadline hit on large response).
 		// Connection's bufio.Reader is mid-body — don't pool it.
-		w.once.Do(func() { w.conn.close() })
+		w.once.Do(func() {
+			w.stopWatching()
+			w.conn.close()
+		})
 		return err
 	}
 	w.handleClose()
 	return nil
 }
 
+func (w *pooledBodyWrapper) stopWatching() {
+	if w.stopWatch != nil {
+		w.stopWatch()
+	}
+}
+
 func (w *pooledBodyWrapper) handleClose() {
 	w.once.Do(func() {
+		w.stopWatching()
+		// A poisoned connection was interrupted mid-exchange by a cancelled
+		// context, so its reader sits at an unknown offset in the response —
+		// reusing it would corrupt the next request. Drop it instead.
+		if !w.keepAlive || w.conn.poisoned.Load() {
+			w.conn.close()
+			return
+		}
 		// Clear deadline before returning conn to pool — the next request
 		// will set its own deadline. Without this, the stale deadline from
 		// the previous request would fire during the next request's I/O.
 		w.conn.conn.SetDeadline(time.Time{})
-		if w.keepAlive {
-			w.transport.putIdleConn(w.key, w.conn)
-		} else {
-			w.conn.close()
-		}
+		w.transport.putIdleConn(w.key, w.conn)
 	})
 }
 
 // streamBodyWrapper wraps response body to close connection when body is closed
 type streamBodyWrapper struct {
-	body io.ReadCloser
-	conn *http1Conn
+	body      io.ReadCloser
+	conn      *http1Conn
+	stopWatch func()
 }
 
 func (w *streamBodyWrapper) Read(p []byte) (n int, err error) {
@@ -327,6 +442,9 @@ func (w *streamBodyWrapper) Read(p []byte) (n int, err error) {
 
 func (w *streamBodyWrapper) Close() error {
 	err := w.body.Close()
+	if w.stopWatch != nil {
+		w.stopWatch()
+	}
 	w.conn.close()
 	return err
 }
@@ -365,16 +483,22 @@ func (t *HTTP1Transport) StreamRoundTrip(req *http.Request) (*http.Response, err
 		return nil, err
 	}
 
+	stopWatch := watchContext(req.Context(), conn)
 	resp, err := t.doRequest(conn, req)
-	if err != nil {
+	if err != nil || req.Context().Err() != nil {
+		stopWatch()
 		conn.close()
+		if ctxErr := contextError(req.Context()); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return nil, WrapError("stream_request", host, port, "h1", err)
 	}
 
 	// Wrap the response body to close connection when body is closed
 	resp.Body = &streamBodyWrapper{
-		body: resp.Body,
-		conn: conn,
+		body:      resp.Body,
+		conn:      conn,
+		stopWatch: stopWatch,
 	}
 
 	return resp, nil

--- a/transport/http1_transport.go
+++ b/transport/http1_transport.go
@@ -70,20 +70,27 @@ type http1Conn struct {
 	poisoned atomic.Bool
 }
 
-// poison unblocks whatever this connection is currently blocked on and marks it
-// unfit for reuse.
+// poison unblocks whatever this connection is currently blocked on and retires
+// it: the socket is dropped, not merely flagged.
 //
-// It deliberately touches only the socket deadline and an atomic flag. doRequest
-// holds c.mu for the full duration of an exchange and close() also takes c.mu,
-// so a watchdog that tried to close the connection would deadlock against the
-// very exchange it is trying to interrupt. Setting a deadline in the past makes
-// any in-flight Read or Write return immediately, and net.Conn deadlines are
-// safe to set from another goroutine.
+// It deliberately goes straight at the socket instead of calling close().
+// doRequest holds c.mu for the full duration of an exchange and close() also
+// takes c.mu, so a watchdog routed through close() would wait on the very read
+// it is trying to interrupt. c.mu guards the bookkeeping, though, not the
+// socket: SetDeadline and Close both need no lock, are safe from another
+// goroutine, and either one unblocks an in-flight Read or Write. Closing as
+// well as moving the deadline means no ordering accident can hand a live but
+// poisoned connection to the next request.
+//
+// c.closed stays false so a later close() still runs its bookkeeping; the
+// second Close on the socket is a no-op error we do not care about.
 func (c *http1Conn) poison() {
 	c.poisoned.Store(true)
-	if c.conn != nil {
-		c.conn.SetDeadline(time.Now())
+	if c.conn == nil {
+		return
 	}
+	c.conn.SetDeadline(time.Now())
+	c.conn.Close()
 }
 
 // contextError reports why the request context ended, or nil if it has not.
@@ -104,6 +111,26 @@ func contextError(ctx context.Context) error {
 	return nil
 }
 
+// translateBodyError reports a body read that ended because the caller gave up
+// as the caller's own cancellation. Without it they get the raw socket error the
+// poisoned deadline produced ("i/o timeout"), indistinguishable from a genuine
+// network fault, and a retry loop happily re-issues a request the caller
+// deliberately abandoned. RoundTrip covers the header wait this way already;
+// the body read is the longer and more commonly cancelled half.
+//
+// It does not gate on conn.poisoned: when the context carried a deadline,
+// doRequest armed the socket with that same deadline, so the read fails on its
+// own a hair before the watchdog gets there and poisoned is still false.
+func translateBodyError(ctx context.Context, err error) error {
+	if ctx == nil {
+		return err
+	}
+	if ctxErr := contextError(ctx); ctxErr != nil {
+		return ctxErr
+	}
+	return err
+}
+
 // watchContext makes a cancelled context interrupt an in-flight HTTP/1.1
 // exchange, and returns a function that stops watching.
 //
@@ -119,16 +146,18 @@ func watchContext(ctx context.Context, conn *http1Conn) func() {
 		return func() {}
 	}
 	stop := make(chan struct{})
-	var finished atomic.Bool
+	exited := make(chan struct{})
 	go func() {
+		defer close(exited)
 		select {
 		case <-done:
 			// Both channels can be closed by the time this goroutine runs: the
 			// exchange finishes, then doHTTP1's deferred cancel fires micro-
 			// seconds later. A select with two ready cases picks at random, so
-			// without this guard the watchdog could poison a healthy connection
-			// just as it returned to the pool, silently killing keep-alive.
-			if !finished.Load() {
+			// re-check before poisoning a connection that already completed.
+			select {
+			case <-stop:
+			default:
 				conn.poison()
 			}
 		case <-stop:
@@ -137,8 +166,12 @@ func watchContext(ctx context.Context, conn *http1Conn) func() {
 	var once sync.Once
 	return func() {
 		once.Do(func() {
-			finished.Store(true)
 			close(stop)
+			// Wait for the watchdog to settle. Callers read conn.poisoned right
+			// after this returns to decide whether to pool the connection; the
+			// value has to be final by then, or a poisoned connection races
+			// into the pool.
+			<-exited
 		})
 	}
 }
@@ -270,6 +303,7 @@ func (t *HTTP1Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 				transport: t,
 				keepAlive: t.shouldKeepAlive(req, resp),
 				stopWatch: stopWatch,
+				ctx:       req.Context(),
 			}
 			return resp, nil
 		}
@@ -308,6 +342,7 @@ func (t *HTTP1Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		transport: t,
 		keepAlive: t.shouldKeepAlive(req, resp),
 		stopWatch: stopWatch,
+		ctx:       req.Context(),
 	}
 
 	return resp, nil
@@ -360,6 +395,7 @@ func (t *HTTP1Transport) RoundTripWithTLSConn(req *http.Request, tlsConn *utls.U
 		body:      resp.Body,
 		conn:      conn,
 		stopWatch: stopWatch,
+		ctx:       req.Context(),
 	}
 
 	return resp, nil
@@ -377,12 +413,17 @@ type pooledBodyWrapper struct {
 	// stopWatch ends the request's context watchdog. It stays armed until the
 	// body is done, so a cancellation during the body read unblocks too.
 	stopWatch func()
+	ctx       context.Context
 }
 
 func (w *pooledBodyWrapper) Read(p []byte) (n int, err error) {
 	n, err = w.body.Read(p)
 	if err == io.EOF {
 		w.handleClose()
+		return n, err
+	}
+	if err != nil {
+		err = translateBodyError(w.ctx, err)
 	}
 	return n, err
 }
@@ -434,10 +475,15 @@ type streamBodyWrapper struct {
 	body      io.ReadCloser
 	conn      *http1Conn
 	stopWatch func()
+	ctx       context.Context
 }
 
 func (w *streamBodyWrapper) Read(p []byte) (n int, err error) {
-	return w.body.Read(p)
+	n, err = w.body.Read(p)
+	if err != nil && err != io.EOF {
+		err = translateBodyError(w.ctx, err)
+	}
+	return n, err
 }
 
 func (w *streamBodyWrapper) Close() error {
@@ -499,6 +545,7 @@ func (t *HTTP1Transport) StreamRoundTrip(req *http.Request) (*http.Response, err
 		body:      resp.Body,
 		conn:      conn,
 		stopWatch: stopWatch,
+		ctx:       req.Context(),
 	}
 
 	return resp, nil


### PR DESCRIPTION
### Problem

`Do()` ignored context cancellation on the HTTP/1.1 path. The exchange blocks in a socket read that only a deadline can interrupt, and `doRequest` converted the context's *deadline* into a socket deadline once at the start, then never looked at the context again. HTTP/2 and HTTP/3 select on `ctx.Done()` in their own request paths; HTTP/1.1 had nothing.

A caller who cancelled waited out the full response timeout — 30s for a cancel issued at 200ms — and then got back an opaque `i/o timeout` that `errors.Is(err, context.Canceled)` would not match. Cancellation was indistinguishable from a network fault, and retry loops happily re-issued requests the caller had deliberately abandoned.

### Fix

A context watchdog runs for the life of the exchange, body read included. On cancellation it poisons the connection — sets the socket deadline to now and closes it — which unblocks the in-flight read.

It goes at the socket directly rather than through `close()`: `doRequest` holds `c.mu` for the whole exchange and `close()` also takes `c.mu`, so a watchdog routed through it would wait on the very read it is trying to interrupt. `c.mu` guards the bookkeeping, not the socket, and both `SetDeadline` and `Close` are safe from another goroutine.

Errors are translated back into the caller's own `context.Canceled` / `context.DeadlineExceeded`, including the deadline case where the socket read loses the race by microseconds and would otherwise surface as `i/o timeout`.

Poisoned connections are never pooled — their reader sits at an unknown offset in the response, so reuse would corrupt the next request.

### Result

A cancel issued at 200ms now returns in 201ms with `context canceled`. Keep-alive is unaffected: 6 requests still share 1 connection, which confirms the watchdog does not race the deferred cancel that fires microseconds after a healthy exchange completes.

### Tests

`transport/context_cancel_test.go` covers prompt return, error identity, connection-pool integrity after a cancellation, the unchanged deadline path, and keep-alive survival.