### PR TITLE
feat(fingerprint): Firefox 133/148 per-platform presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,7 +1034,14 @@ response.Protocol
 | `chrome-143-linux` | Linux | ✅ | ✅ |
 | `chrome-141` | Auto | ✅ | ❌ |
 | `chrome-133` | Auto | ✅ | ❌ |
+| `firefox-148` | Auto | ✅ | ❌ |
+| `firefox-148-windows` | Windows | ✅ | ❌ |
+| `firefox-148-macos` | macOS | ✅ | ❌ |
+| `firefox-148-linux` | Linux | ✅ | ❌ |
 | `firefox-133` | Auto | ❌ | ❌ |
+| `firefox-133-windows` | Windows | ❌ | ❌ |
+| `firefox-133-macos` | macOS | ❌ | ❌ |
+| `firefox-133-linux` | Linux | ❌ | ❌ |
 | `safari-18` | macOS | ❌ | ✅ |
 | `safari-18-ios` | iOS | ❌ | ✅ |
 | `safari-17-ios` | iOS | ❌ | ❌ |

--- a/fingerprint/embedded/firefox-133-linux.json
+++ b/fingerprint/embedded/firefox-133-linux.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "preset": {
+    "name": "firefox-133-linux",
+    "based_on": "firefox-133",
+    "headers": {
+      "user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:133.0) Gecko/20100101 Firefox/133.0"
+    }
+  }
+}

--- a/fingerprint/embedded/firefox-133-macos.json
+++ b/fingerprint/embedded/firefox-133-macos.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "preset": {
+    "name": "firefox-133-macos",
+    "based_on": "firefox-133",
+    "headers": {
+      "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/133.0"
+    }
+  }
+}

--- a/fingerprint/embedded/firefox-133-windows.json
+++ b/fingerprint/embedded/firefox-133-windows.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "preset": {
+    "name": "firefox-133-windows",
+    "based_on": "firefox-133",
+    "headers": {
+      "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0"
+    }
+  }
+}

--- a/fingerprint/embedded/firefox-148-linux.json
+++ b/fingerprint/embedded/firefox-148-linux.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "preset": {
+    "name": "firefox-148-linux",
+    "based_on": "firefox-148",
+    "headers": {
+      "user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:148.0) Gecko/20100101 Firefox/148.0"
+    }
+  }
+}

--- a/fingerprint/embedded/firefox-148-macos.json
+++ b/fingerprint/embedded/firefox-148-macos.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "preset": {
+    "name": "firefox-148-macos",
+    "based_on": "firefox-148",
+    "headers": {
+      "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:148.0) Gecko/20100101 Firefox/148.0"
+    }
+  }
+}

--- a/fingerprint/embedded/firefox-148-windows.json
+++ b/fingerprint/embedded/firefox-148-windows.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "preset": {
+    "name": "firefox-148-windows",
+    "based_on": "firefox-148",
+    "headers": {
+      "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:148.0) Gecko/20100101 Firefox/148.0"
+    }
+  }
+}

--- a/fingerprint/firefox_platform_test.go
+++ b/fingerprint/firefox_platform_test.go
@@ -1,0 +1,90 @@
+package fingerprint
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Locks the Firefox per-platform preset wiring. Firefox advertises no UA Client
+// Hints and NSS emits the same ClientHello regardless of OS, so a platform
+// variant is its auto-detected base with exactly one field changed: the OS
+// token of the User-Agent. This guards that the embedded JSON loaded (a base
+// fallback would leave the host OS token in place), that the rv: token matches
+// the Firefox version, and that nothing but name and User-Agent differs from
+// the base fingerprint.
+func TestFirefoxPlatformPresets(t *testing.T) {
+	tests := []struct {
+		name   string
+		base   string
+		wantUA string
+	}{
+		{"firefox-133-windows", "firefox-133", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0"},
+		{"firefox-133-linux", "firefox-133", "Mozilla/5.0 (X11; Linux x86_64; rv:133.0) Gecko/20100101 Firefox/133.0"},
+		{"firefox-133-macos", "firefox-133", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/133.0"},
+		{"firefox-148-windows", "firefox-148", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:148.0) Gecko/20100101 Firefox/148.0"},
+		{"firefox-148-linux", "firefox-148", "Mozilla/5.0 (X11; Linux x86_64; rv:148.0) Gecko/20100101 Firefox/148.0"},
+		{"firefox-148-macos", "firefox-148", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:148.0) Gecko/20100101 Firefox/148.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Get(tt.name)
+			if p == nil {
+				t.Fatalf("%s: not registered", tt.name)
+			}
+			if p.UserAgent != tt.wantUA {
+				t.Errorf("%s: UA = %q, want %q (embedded JSON may not have loaded)", tt.name, p.UserAgent, tt.wantUA)
+			}
+
+			// Only name and User-Agent may differ from the base. Describe
+			// flattens both to fully-resolved JSON, so blanking those two
+			// fields makes the specs compare equal iff nothing else differs -
+			// the TLS ClientHello, HTTP/2 settings and header order in
+			// particular.
+			if got, want := normalizedFirefoxSpec(t, tt.name), normalizedFirefoxSpec(t, tt.base); got != want {
+				t.Errorf("%s differs from base %s beyond name and user-agent", tt.name, tt.base)
+			}
+		})
+	}
+}
+
+// Firefox family names must resolve to real presets so a preset pool built from
+// them does not silently fall back to Chrome via Get.
+func TestFirefoxPlatformPresetsRegistered(t *testing.T) {
+	for _, name := range []string{
+		"firefox-133-windows", "firefox-133-linux", "firefox-133-macos",
+		"firefox-148-windows", "firefox-148-linux", "firefox-148-macos",
+		"firefox-latest-windows", "firefox-latest-linux", "firefox-latest-macos",
+	} {
+		if GetStrict(name) == nil {
+			t.Errorf("%s: not registered (GetStrict returned nil)", name)
+		}
+	}
+}
+
+// normalizedFirefoxSpec describes a preset and deletes the two fields a
+// platform variant is allowed to change - the preset name and the User-Agent -
+// so two specs compare equal iff nothing else differs.
+func normalizedFirefoxSpec(t *testing.T, name string) string {
+	t.Helper()
+	described, err := Describe(name)
+	if err != nil {
+		t.Fatalf("describe %q: %v", name, err)
+	}
+	var file map[string]any
+	if err := json.Unmarshal([]byte(described), &file); err != nil {
+		t.Fatalf("parse described %q: %v", name, err)
+	}
+	preset, ok := file["preset"].(map[string]any)
+	if !ok {
+		t.Fatalf("described %q has no preset object", name)
+	}
+	delete(preset, "name")
+	if h, ok := preset["headers"].(map[string]any); ok {
+		delete(h, "user_agent")
+	}
+	out, err := json.Marshal(file)
+	if err != nil {
+		t.Fatalf("re-encode %q: %v", name, err)
+	}
+	return string(out)
+}

--- a/fingerprint/presets.go
+++ b/fingerprint/presets.go
@@ -1026,6 +1026,59 @@ func Firefox148() *Preset {
 	}
 }
 
+// Firefox133Windows returns Firefox 133 on Windows. Firefox has no UA Client
+// Hints and NSS emits the same ClientHello on every OS, so a platform variant
+// differs from the auto-detected base in exactly one place: the OS token of the
+// User-Agent. The variant presets live in embedded JSON (based_on the auto base,
+// user_agent override only); this falls back to the auto-detected base if the
+// JSON didn't load, mirroring the Chrome 150 accessors.
+func Firefox133Windows() *Preset {
+	if p := LookupCustom("firefox-133-windows"); p != nil {
+		return p
+	}
+	return Firefox133()
+}
+
+// Firefox133Linux returns Firefox 133 on Linux. See Firefox133Windows.
+func Firefox133Linux() *Preset {
+	if p := LookupCustom("firefox-133-linux"); p != nil {
+		return p
+	}
+	return Firefox133()
+}
+
+// Firefox133macOS returns Firefox 133 on macOS. See Firefox133Windows.
+func Firefox133macOS() *Preset {
+	if p := LookupCustom("firefox-133-macos"); p != nil {
+		return p
+	}
+	return Firefox133()
+}
+
+// Firefox148Windows returns Firefox 148 on Windows. See Firefox133Windows.
+func Firefox148Windows() *Preset {
+	if p := LookupCustom("firefox-148-windows"); p != nil {
+		return p
+	}
+	return Firefox148()
+}
+
+// Firefox148Linux returns Firefox 148 on Linux. See Firefox133Windows.
+func Firefox148Linux() *Preset {
+	if p := LookupCustom("firefox-148-linux"); p != nil {
+		return p
+	}
+	return Firefox148()
+}
+
+// Firefox148macOS returns Firefox 148 on macOS. See Firefox133Windows.
+func Firefox148macOS() *Preset {
+	if p := LookupCustom("firefox-148-macos"); p != nil {
+		return p
+	}
+	return Firefox148()
+}
+
 // Chrome143 returns the Chrome 143 fingerprint preset with platform-specific TLS fingerprint
 func Chrome143() *Preset {
 	p := GetPlatformInfo()
@@ -2817,71 +2870,80 @@ func AndroidChrome145() *Preset {
 
 // presets is a map of all available presets
 var presets = map[string]func() *Preset{
-	"chrome-133":         Chrome133,
-	"chrome-141":         Chrome141,
-	"chrome-143":         Chrome143,
-	"chrome-143-windows": Chrome143Windows,
-	"chrome-143-linux":   Chrome143Linux,
-	"chrome-143-macos":   Chrome143macOS,
-	"chrome-144":         Chrome144,
-	"chrome-144-windows": Chrome144Windows,
-	"chrome-144-linux":   Chrome144Linux,
-	"chrome-144-macos":   Chrome144macOS,
-	"chrome-145":         Chrome145,
-	"chrome-145-windows": Chrome145Windows,
-	"chrome-145-linux":   Chrome145Linux,
-	"chrome-145-macos":   Chrome145macOS,
-	"chrome-146":         Chrome146,
-	"chrome-146-windows": Chrome146Windows,
-	"chrome-146-linux":   Chrome146Linux,
-	"chrome-146-macos":   Chrome146macOS,
-	"chrome-147":         Chrome147,
-	"chrome-147-windows": Chrome147Windows,
-	"chrome-147-linux":   Chrome147Linux,
-	"chrome-147-macos":   Chrome147macOS,
-	"firefox-133":        Firefox133,
-	"firefox-148":        Firefox148,
-	"safari-18":          Safari18,
-	"chrome-143-ios":     IOSChrome143,
-	"chrome-144-ios":     IOSChrome144,
-	"chrome-145-ios":     IOSChrome145,
-	"chrome-146-ios":     IOSChrome146,
-	"safari-17-ios":      IOSSafari17,
-	"safari-18-ios":      IOSSafari18,
-	"chrome-143-android": AndroidChrome143,
-	"chrome-144-android": AndroidChrome144,
-	"chrome-145-android": AndroidChrome145,
-	"chrome-146-android": AndroidChrome146,
-	"chrome-147-ios":     IOSChrome147,
-	"chrome-147-android": AndroidChrome147,
-	"chrome-148-ios":     IOSChrome148,
-	"chrome-148":         Chrome148,
-	"chrome-148-windows": Chrome148Windows,
-	"chrome-148-linux":   Chrome148Linux,
-	"chrome-148-macos":   Chrome148macOS,
-	"chrome-148-android": AndroidChrome148,
-	"chrome-149":         Chrome149,
-	"chrome-149-windows": Chrome149Windows,
-	"chrome-149-linux":   Chrome149Linux,
-	"chrome-149-macos":   Chrome149macOS,
-	"chrome-150":         Chrome150,
-	"chrome-150-windows": Chrome150Windows,
-	"chrome-150-linux":   Chrome150Linux,
-	"chrome-150-macos":   Chrome150macOS,
-	"chrome-150-ios":     IOSChrome150,
-	"chrome-150-android": AndroidChrome150,
+	"chrome-133":          Chrome133,
+	"chrome-141":          Chrome141,
+	"chrome-143":          Chrome143,
+	"chrome-143-windows":  Chrome143Windows,
+	"chrome-143-linux":    Chrome143Linux,
+	"chrome-143-macos":    Chrome143macOS,
+	"chrome-144":          Chrome144,
+	"chrome-144-windows":  Chrome144Windows,
+	"chrome-144-linux":    Chrome144Linux,
+	"chrome-144-macos":    Chrome144macOS,
+	"chrome-145":          Chrome145,
+	"chrome-145-windows":  Chrome145Windows,
+	"chrome-145-linux":    Chrome145Linux,
+	"chrome-145-macos":    Chrome145macOS,
+	"chrome-146":          Chrome146,
+	"chrome-146-windows":  Chrome146Windows,
+	"chrome-146-linux":    Chrome146Linux,
+	"chrome-146-macos":    Chrome146macOS,
+	"chrome-147":          Chrome147,
+	"chrome-147-windows":  Chrome147Windows,
+	"chrome-147-linux":    Chrome147Linux,
+	"chrome-147-macos":    Chrome147macOS,
+	"firefox-133":         Firefox133,
+	"firefox-133-windows": Firefox133Windows,
+	"firefox-133-linux":   Firefox133Linux,
+	"firefox-133-macos":   Firefox133macOS,
+	"firefox-148":         Firefox148,
+	"firefox-148-windows": Firefox148Windows,
+	"firefox-148-linux":   Firefox148Linux,
+	"firefox-148-macos":   Firefox148macOS,
+	"safari-18":           Safari18,
+	"chrome-143-ios":      IOSChrome143,
+	"chrome-144-ios":      IOSChrome144,
+	"chrome-145-ios":      IOSChrome145,
+	"chrome-146-ios":      IOSChrome146,
+	"safari-17-ios":       IOSSafari17,
+	"safari-18-ios":       IOSSafari18,
+	"chrome-143-android":  AndroidChrome143,
+	"chrome-144-android":  AndroidChrome144,
+	"chrome-145-android":  AndroidChrome145,
+	"chrome-146-android":  AndroidChrome146,
+	"chrome-147-ios":      IOSChrome147,
+	"chrome-147-android":  AndroidChrome147,
+	"chrome-148-ios":      IOSChrome148,
+	"chrome-148":          Chrome148,
+	"chrome-148-windows":  Chrome148Windows,
+	"chrome-148-linux":    Chrome148Linux,
+	"chrome-148-macos":    Chrome148macOS,
+	"chrome-148-android":  AndroidChrome148,
+	"chrome-149":          Chrome149,
+	"chrome-149-windows":  Chrome149Windows,
+	"chrome-149-linux":    Chrome149Linux,
+	"chrome-149-macos":    Chrome149macOS,
+	"chrome-150":          Chrome150,
+	"chrome-150-windows":  Chrome150Windows,
+	"chrome-150-linux":    Chrome150Linux,
+	"chrome-150-macos":    Chrome150macOS,
+	"chrome-150-ios":      IOSChrome150,
+	"chrome-150-android":  AndroidChrome150,
 
 	// -latest aliases (always point to the newest version). Desktop, iOS and
 	// Android all track 150.
-	"chrome-latest":         Chrome150,
-	"chrome-latest-windows": Chrome150Windows,
-	"chrome-latest-linux":   Chrome150Linux,
-	"chrome-latest-macos":   Chrome150macOS,
-	"firefox-latest":        Firefox148,
-	"safari-latest":         Safari18,
-	"chrome-latest-ios":     IOSChrome150,
-	"safari-latest-ios":     IOSSafari18,
-	"chrome-latest-android": AndroidChrome150,
+	"chrome-latest":          Chrome150,
+	"chrome-latest-windows":  Chrome150Windows,
+	"chrome-latest-linux":    Chrome150Linux,
+	"chrome-latest-macos":    Chrome150macOS,
+	"firefox-latest":         Firefox148,
+	"firefox-latest-windows": Firefox148Windows,
+	"firefox-latest-linux":   Firefox148Linux,
+	"firefox-latest-macos":   Firefox148macOS,
+	"safari-latest":          Safari18,
+	"chrome-latest-ios":      IOSChrome150,
+	"safari-latest-ios":      IOSSafari18,
+	"chrome-latest-android":  AndroidChrome150,
 
 	// Backwards compatibility aliases (old naming convention)
 	"ios-chrome-143":        IOSChrome143,


### PR DESCRIPTION
Closes #94. Related to #49 (Firefox 148 profile request).

### Problem

Chrome has per-platform presets (`chrome-150-windows` / `-linux` / `-macos`) for every recent version, but Firefox has only the bare `firefox-133` / `firefox-148`, which auto-detect the host OS via `runtime.GOOS`. A caller on a Linux server cannot pin Firefox-on-Windows without a `describe_preset` -> mutate -> `load_preset_from_json` cycle.

### Change

Adds `firefox-{133,148}-{windows,linux,macos}` plus `firefox-latest-{windows,linux,macos}` aliases, completing the platform matrix symmetry with `chrome-latest-*`.

Firefox sends no UA Client Hints and NSS emits the same ClientHello on every OS, so the platform lives in exactly one field: the OS token of the `User-Agent`. Each variant is an embedded JSON preset `based_on` its auto-detected base with only `headers.user_agent` overridden - TLS, HTTP/2 SETTINGS, HPACK order and header order inherit byte-exact from the base.

The Go accessors mirror the Chrome 150 pattern: `LookupCustom` first, fall back to the auto-detected base if the embedded JSON did not load. The bare `firefox-133` / `firefox-148` names keep their `runtime.GOOS` auto-detection unchanged.

The preset map re-alignment in `presets.go` is gofmt's doing - `firefox-133-windows` is one character longer than the previous widest key, so the value column shifts by one space. Whitespace-only; hide-whitespace collapses it.

### Tests

`fingerprint/firefox_platform_test.go`:

- exact `User-Agent` per variant, with the `rv:` token matching the Firefox version - a base fallback would leave the host OS token in place, so this also proves the embedded JSON actually loaded
- via `Describe`, that a variant differs from its base in nothing but name and `User-Agent` - locking the TLS ClientHello, HTTP/2 settings and header order to the base
- all six variants plus the three `-latest` aliases resolve through `GetStrict`, so a name typo cannot silently fall back to Chrome via `Get`

`go test ./fingerprint/` passes.

### README

Adds the nine names to the preset table with their platform column.
