### PR TITLE
Add Response.Location() — resolve the redirect target like net/http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`Response.Location()` resolves the redirect target the way `net/http` does**: the standard library's `http.Response` has a `Location()` method that parses the `Location` header into a `*url.URL` and resolves it against the request URL, so a relative `/login` comes back as the full `https://host/login`. httpcloak responses only exposed the raw header string, which left anyone inspecting a 3xx with redirects disabled to re-implement that resolution by hand. The `Response` types in the root, `client`, and `transport` packages now carry the same method: it parses the header, resolves a relative target against the URL that produced the response (`FinalURL`), and returns the package's `ErrNoLocation` sentinel when no `Location` header is present — matching `net/http` semantics exactly, which is locked by a parity test that runs the same cases through both implementations.
+
 ## [1.6.8] - 2026-07-13
 
 ### Added

--- a/client/client.go
+++ b/client/client.go
@@ -45,6 +45,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -559,6 +560,27 @@ func (r *Response) GetHeader(key string) string {
 // GetHeaders returns all values for the given header key (case-insensitive).
 func (r *Response) GetHeaders(key string) []string {
 	return r.Headers[strings.ToLower(key)]
+}
+
+// ErrNoLocation is returned by Response.Location when the response has no
+// Location header.
+var ErrNoLocation = errors.New("httpcloak/client: no Location header in response")
+
+// Location returns the URL of the response's "Location" header, if present.
+// A relative Location is resolved against the URL of the request that produced
+// the response (FinalURL), mirroring net/http's Response.Location.
+// ErrNoLocation is returned when no Location header is present.
+func (r *Response) Location() (*url.URL, error) {
+	lv := r.GetHeader("Location")
+	if lv == "" {
+		return nil, ErrNoLocation
+	}
+	if r.FinalURL != "" {
+		if base, err := url.Parse(r.FinalURL); err == nil {
+			return base.Parse(lv)
+		}
+	}
+	return url.Parse(lv)
 }
 
 // IsSuccess returns true if the status code is 2xx

--- a/client/location_test.go
+++ b/client/location_test.go
@@ -1,0 +1,94 @@
+package client
+
+import (
+	"errors"
+	stdhttp "net/http"
+	"net/url"
+	"testing"
+)
+
+// locationCases drives both the direct tests and the net/http parity check.
+// FinalURL is the URL of the request that produced the response; location is
+// the raw Location header value as a server would send it.
+var locationCases = []struct {
+	name     string
+	finalURL string
+	location string
+	want     string
+}{
+	{"absolute", "https://example.com/start", "https://other.example/next", "https://other.example/next"},
+	{"root relative", "https://example.com/a/b?q=1", "/login", "https://example.com/login"},
+	{"path relative", "https://example.com/a/b", "c/d", "https://example.com/a/c/d"},
+	{"parent traversal", "https://example.com/a/b/c", "../up", "https://example.com/a/up"},
+	{"query only", "https://example.com/a", "?page=2", "https://example.com/a?page=2"},
+	{"fragment only", "https://example.com/a", "#section", "https://example.com/a#section"},
+	{"protocol relative", "https://example.com/a", "//cdn.example/x", "https://cdn.example/x"},
+	{"scheme downgrade", "https://example.com/a", "http://example.com/plain", "http://example.com/plain"},
+	{"no base absolute", "", "https://example.com/abs", "https://example.com/abs"},
+	{"no base relative", "", "/login", "/login"},
+}
+
+func TestResponseLocation(t *testing.T) {
+	for _, tt := range locationCases {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &Response{
+				FinalURL: tt.finalURL,
+				Headers:  map[string][]string{"location": {tt.location}},
+			}
+			got, err := resp.Location()
+			if err != nil {
+				t.Fatalf("Location() error = %v", err)
+			}
+			if got.String() != tt.want {
+				t.Errorf("Location() = %q, want %q", got.String(), tt.want)
+			}
+		})
+	}
+}
+
+// TestResponseLocationStdlibParity locks the resolution semantics to
+// net/http's Response.Location: same header, same base URL, same result.
+func TestResponseLocationStdlibParity(t *testing.T) {
+	for _, tt := range locationCases {
+		t.Run(tt.name, func(t *testing.T) {
+			std := &stdhttp.Response{
+				Header: stdhttp.Header{"Location": {tt.location}},
+			}
+			if tt.finalURL != "" {
+				base, err := url.Parse(tt.finalURL)
+				if err != nil {
+					t.Fatalf("parse base: %v", err)
+				}
+				std.Request = &stdhttp.Request{URL: base}
+			}
+			want, err := std.Location()
+			if err != nil {
+				t.Fatalf("stdlib Location() error = %v", err)
+			}
+
+			resp := &Response{
+				FinalURL: tt.finalURL,
+				Headers:  map[string][]string{"location": {tt.location}},
+			}
+			got, err := resp.Location()
+			if err != nil {
+				t.Fatalf("Location() error = %v", err)
+			}
+			if got.String() != want.String() {
+				t.Errorf("Location() = %q, stdlib = %q", got.String(), want.String())
+			}
+		})
+	}
+}
+
+func TestResponseLocationMissing(t *testing.T) {
+	for _, resp := range []*Response{
+		{FinalURL: "https://example.com/", Headers: nil},
+		{FinalURL: "https://example.com/", Headers: map[string][]string{}},
+		{FinalURL: "https://example.com/", Headers: map[string][]string{"location": {""}}},
+	} {
+		if _, err := resp.Location(); !errors.Is(err, ErrNoLocation) {
+			t.Errorf("Location() error = %v, want ErrNoLocation", err)
+		}
+	}
+}

--- a/docs/docs/bindings/go.md
+++ b/docs/docs/bindings/go.md
@@ -313,9 +313,12 @@ func (r *Response) Text() (string, error)
 func (r *Response) JSON(v interface{}) error
 func (r *Response) GetHeader(key string) string
 func (r *Response) GetHeaders(key string) []string
+func (r *Response) Location() (*url.URL, error)
 ```
 
 `Bytes`, `Text`, `JSON` cache the body after the first read. `GetHeader` / `GetHeaders` look up case-insensitively against the lowercase keys.
+
+`Location` mirrors `net/http`'s `Response.Location`: it parses the `Location` header and resolves a relative target against the URL that produced the response (`FinalURL`), so a 3xx surfaced with redirects disabled gives you the absolute next URL directly. It returns `httpcloak.ErrNoLocation` when the response has no `Location` header.
 
 `History` is the list of intermediate redirects the request went through. Each entry has `StatusCode`, `URL`, and `Headers`.
 

--- a/httpcloak.go
+++ b/httpcloak.go
@@ -27,11 +27,13 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
 	"net"
 	"net/textproto"
+	"net/url"
 	"strings"
 	"time"
 
@@ -278,6 +280,29 @@ func (r *Response) GetHeader(key string) string {
 // GetHeaders returns all values for the given header key.
 func (r *Response) GetHeaders(key string) []string {
 	return r.Headers[strings.ToLower(key)]
+}
+
+// ErrNoLocation is returned by Response.Location when the response has no
+// Location header.
+var ErrNoLocation = errors.New("httpcloak: no Location header in response")
+
+// Location returns the URL of the response's "Location" header, if present.
+// A relative Location is resolved against the URL of the request that produced
+// the response (FinalURL), mirroring net/http's Response.Location. Useful for
+// inspecting 3xx responses when redirects are disabled via WithoutRedirects or
+// Request.FollowRedirects. ErrNoLocation is returned when no Location header
+// is present.
+func (r *Response) Location() (*url.URL, error) {
+	lv := r.GetHeader("Location")
+	if lv == "" {
+		return nil, ErrNoLocation
+	}
+	if r.FinalURL != "" {
+		if base, err := url.Parse(r.FinalURL); err == nil {
+			return base.Parse(lv)
+		}
+	}
+	return url.Parse(lv)
 }
 
 // Do executes an HTTP request

--- a/transport/location_test.go
+++ b/transport/location_test.go
@@ -1,0 +1,108 @@
+package transport
+
+import (
+	"errors"
+	stdhttp "net/http"
+	"net/url"
+	"testing"
+)
+
+// locationCases drives both the direct tests and the net/http parity check.
+// FinalURL is the URL of the request that produced the response; location is
+// the raw Location header value as a server would send it.
+var locationCases = []struct {
+	name     string
+	finalURL string
+	location string
+	want     string
+}{
+	{"absolute", "https://example.com/start", "https://other.example/next", "https://other.example/next"},
+	{"root relative", "https://example.com/a/b?q=1", "/login", "https://example.com/login"},
+	{"path relative", "https://example.com/a/b", "c/d", "https://example.com/a/c/d"},
+	{"parent traversal", "https://example.com/a/b/c", "../up", "https://example.com/a/up"},
+	{"query only", "https://example.com/a", "?page=2", "https://example.com/a?page=2"},
+	{"fragment only", "https://example.com/a", "#section", "https://example.com/a#section"},
+	{"protocol relative", "https://example.com/a", "//cdn.example/x", "https://cdn.example/x"},
+	{"scheme downgrade", "https://example.com/a", "http://example.com/plain", "http://example.com/plain"},
+	{"no base absolute", "", "https://example.com/abs", "https://example.com/abs"},
+	{"no base relative", "", "/login", "/login"},
+}
+
+func TestResponseLocation(t *testing.T) {
+	for _, tt := range locationCases {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &Response{
+				FinalURL: tt.finalURL,
+				Headers:  map[string][]string{"location": {tt.location}},
+			}
+			got, err := resp.Location()
+			if err != nil {
+				t.Fatalf("Location() error = %v", err)
+			}
+			if got.String() != tt.want {
+				t.Errorf("Location() = %q, want %q", got.String(), tt.want)
+			}
+		})
+	}
+}
+
+// TestResponseLocationStdlibParity locks the resolution semantics to
+// net/http's Response.Location: same header, same base URL, same result.
+func TestResponseLocationStdlibParity(t *testing.T) {
+	for _, tt := range locationCases {
+		t.Run(tt.name, func(t *testing.T) {
+			std := &stdhttp.Response{
+				Header: stdhttp.Header{"Location": {tt.location}},
+			}
+			if tt.finalURL != "" {
+				base, err := url.Parse(tt.finalURL)
+				if err != nil {
+					t.Fatalf("parse base: %v", err)
+				}
+				std.Request = &stdhttp.Request{URL: base}
+			}
+			want, err := std.Location()
+			if err != nil {
+				t.Fatalf("stdlib Location() error = %v", err)
+			}
+
+			resp := &Response{
+				FinalURL: tt.finalURL,
+				Headers:  map[string][]string{"location": {tt.location}},
+			}
+			got, err := resp.Location()
+			if err != nil {
+				t.Fatalf("Location() error = %v", err)
+			}
+			if got.String() != want.String() {
+				t.Errorf("Location() = %q, stdlib = %q", got.String(), want.String())
+			}
+		})
+	}
+}
+
+func TestResponseLocationMissing(t *testing.T) {
+	for _, resp := range []*Response{
+		{FinalURL: "https://example.com/", Headers: nil},
+		{FinalURL: "https://example.com/", Headers: map[string][]string{}},
+		{FinalURL: "https://example.com/", Headers: map[string][]string{"location": {""}}},
+	} {
+		if _, err := resp.Location(); !errors.Is(err, ErrNoLocation) {
+			t.Errorf("Location() error = %v, want ErrNoLocation", err)
+		}
+	}
+}
+
+func TestResponseLocationFirstValueWins(t *testing.T) {
+	resp := &Response{
+		FinalURL: "https://example.com/",
+		Headers:  map[string][]string{"location": {"/first", "/second"}},
+	}
+	got, err := resp.Location()
+	if err != nil {
+		t.Fatalf("Location() error = %v", err)
+	}
+	if got.String() != "https://example.com/first" {
+		t.Errorf("Location() = %q, want %q", got.String(), "https://example.com/first")
+	}
+}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -263,6 +263,27 @@ func (r *Response) GetHeaders(key string) []string {
 	return r.Headers[strings.ToLower(key)]
 }
 
+// ErrNoLocation is returned by Response.Location when the response has no
+// Location header.
+var ErrNoLocation = errors.New("httpcloak/transport: no Location header in response")
+
+// Location returns the URL of the response's "Location" header, if present.
+// A relative Location is resolved against the URL of the request that produced
+// the response (FinalURL), mirroring net/http's Response.Location.
+// ErrNoLocation is returned when no Location header is present.
+func (r *Response) Location() (*url.URL, error) {
+	lv := r.GetHeader("Location")
+	if lv == "" {
+		return nil, ErrNoLocation
+	}
+	if r.FinalURL != "" {
+		if base, err := url.Parse(r.FinalURL); err == nil {
+			return base.Parse(lv)
+		}
+	}
+	return url.Parse(lv)
+}
+
 // Bytes returns the response body as a byte slice.
 // If the body has already been read, returns the cached bytes.
 // Otherwise reads the body and caches it.


### PR DESCRIPTION
## What

Adds the stdlib's `Response.Location()` to httpcloak's response types (root, `client`, `transport`): it parses the `Location` header into a `*url.URL`, resolving a relative target (`/login`, `../up`, `//cdn.example/x`, `?page=2`) against the URL that produced the response (`FinalURL` — the same base `net/http` uses via `Response.Request`). A missing header returns the package's `ErrNoLocation` sentinel, matching the stdlib contract.

## Why

With redirects disabled (`WithoutRedirects()` or the per-request override), a surfaced 3xx only exposes the raw header string, so every caller re-implements relative-URL resolution by hand. `net/http` users expect this method to exist.

## Testing

- Table-driven tests in `transport/` and `client/` covering absolute, root/path-relative, parent-traversal, query/fragment-only, and protocol-relative targets, plus missing/empty-header and duplicate-header edges.
- A parity test runs the identical cases through `net/http.Response.Location` and asserts equal output.
- Verified end-to-end against a local HTTP/2 server: a real 302 with a relative `Location`, fetched through a `Session` with redirects disabled, resolves to the correct absolute URL.

Changelog entry and Go docs included.