### PR TITLE
fix(pool): stop racing on the connection use counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A data race between concurrent requests sharing a pooled connection**: the pool records a use count on every connection it hands out, writing it under the connection's mutex. Three callers then read that counter straight off the struct with no lock at all, to decide whether the connection was newly established and therefore whether the connect time should be attributed to DNS, TCP and TLS in the reported timings. On HTTP/2 and HTTP/3 a single connection is shared by many requests at once, so two overlapping requests on the same connection would collide: one inside the guarded write, the other reading the field bare. The counter is now read through an accessor that takes the same mutex, on both the TCP and QUIC connection types, and the pool's own statistics call goes through it too. What was actually at stake is small — the value only decides how a few milliseconds are split across the timing fields, never whether a request is sent or what it contains — but it is a genuine race, and it made builds run with the race detector fail intermittently, at roughly one run in four to eight.
+
 ## [1.6.10] - 2026-08-14
 
 ### Added

--- a/client/client.go
+++ b/client/client.go
@@ -1386,7 +1386,7 @@ func (c *Client) doHTTP3(ctx context.Context, host, port string, httpReq *http.R
 	}
 
 	// Calculate timing
-	if conn.UseCount == 1 {
+	if conn.Uses() == 1 {
 		connTime := float64(time.Since(connStart).Milliseconds())
 		timing.DNSLookup = connTime / 3
 		timing.TCPConnect = 0
@@ -1421,8 +1421,10 @@ func (c *Client) doHTTP2(ctx context.Context, host, port string, httpReq *http.R
 		return nil, "", fmt.Errorf("failed to get connection: %w", err)
 	}
 
-	// Calculate timing
-	if conn.UseCount == 1 {
+	// Calculate timing. Uses(), not conn.UseCount: the pool bumps that counter
+	// under the connection's mutex in MarkUsed, so a bare read here races with
+	// any other request acquiring the same multiplexed H2 connection.
+	if conn.Uses() == 1 {
 		connTime := float64(time.Since(connStart).Milliseconds())
 		timing.DNSLookup = connTime / 3
 		timing.TCPConnect = connTime / 3

--- a/client/http3_client.go
+++ b/client/http3_client.go
@@ -110,7 +110,7 @@ func (c *HTTP3Client) Do(ctx context.Context, req *Request) (*Response, error) {
 	}
 
 	// Calculate timing based on whether this is a new connection
-	if conn.UseCount == 1 {
+	if conn.Uses() == 1 {
 		// New connection - estimate timing breakdown
 		connTime := float64(time.Since(connStart).Milliseconds())
 		timing.DNSLookup = connTime / 3

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -41,6 +41,9 @@ type Conn struct {
 	TLSConn    *utls.UConn
 	HTTP2Conn  *http2.ClientConn
 	CreatedAt  time.Time
+	// LastUsedAt and UseCount are written under mu for the whole life of the
+	// connection, so once the pool owns it read them through IdleTime() and
+	// Uses() rather than off the struct.
 	LastUsedAt time.Time
 	UseCount   int64
 	mu         sync.Mutex
@@ -204,6 +207,19 @@ func (c *Conn) IdleTime() time.Duration {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return time.Since(c.LastUsedAt)
+}
+
+// Uses returns how many times the pool has handed this connection out.
+//
+// MarkUsed() writes UseCount under c.mu on every acquisition, so anything on
+// another goroutine has to read it through here. Two requests multiplexing on
+// the same HTTP/2 connection otherwise race outright: GetConn calls MarkUsed on
+// the connection it returns, so one caller is inside that write while the other
+// reads the field bare.
+func (c *Conn) Uses() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.UseCount
 }
 
 // MarkUsed updates the last used timestamp
@@ -1276,7 +1292,7 @@ func (p *HostPool) Stats() (total int, healthy int, totalRequests int64) {
 		if conn.IsHealthy() {
 			healthy++
 		}
-		totalRequests += conn.UseCount
+		totalRequests += conn.Uses()
 	}
 	return
 }

--- a/pool/quic_pool.go
+++ b/pool/quic_pool.go
@@ -46,6 +46,7 @@ type QUICConn struct {
 	QUICConn   *quic.Conn
 	HTTP3RT    *http3.Transport
 	CreatedAt  time.Time
+	// Written under mu, same as on Conn: read via IdleTime()/Uses().
 	LastUsedAt time.Time
 	UseCount   int64
 	mu         sync.Mutex
@@ -191,6 +192,15 @@ func (c *QUICConn) IdleTime() time.Duration {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return time.Since(c.LastUsedAt)
+}
+
+// Uses returns how many times the pool has handed this connection out. Guarded
+// for the same reason as (*Conn).Uses: MarkUsed() writes the field under c.mu at
+// acquisition, so a bare read from another goroutine is a data race.
+func (c *QUICConn) Uses() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.UseCount
 }
 
 // MarkUsed updates the last used timestamp
@@ -763,7 +773,7 @@ func (p *QUICHostPool) Stats() (total int, healthy int, totalRequests int64) {
 		if conn.IsHealthy() {
 			healthy++
 		}
-		totalRequests += conn.UseCount
+		totalRequests += conn.Uses()
 	}
 	return
 }

--- a/pool/usecount_race_test.go
+++ b/pool/usecount_race_test.go
@@ -1,0 +1,91 @@
+package pool
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// Regression locks for the UseCount data race.
+//
+// MarkUsed() writes LastUsedAt and UseCount under c.mu, and GetConn calls it on
+// whichever connection it hands out. client/ then read conn.UseCount straight
+// off the struct to decide whether the connection was brand new, purely to
+// attribute the connect time across the Timing fields. Two requests multiplexing
+// on the same HTTP/2 connection therefore raced: one inside the guarded write,
+// the other reading the field bare. The visible damage was only wrong timing
+// attribution, but -race builds failed on it roughly one run in four to eight
+// (TestPoolReuseConcurrent in client/).
+//
+// Every read outside the write itself now goes through Uses(). These tests are
+// only meaningful under -race; without it they just check the arithmetic.
+
+func TestConnUsesUnderConcurrentMarkUsed(t *testing.T) {
+	conn := &Conn{Host: "example.com", CreatedAt: time.Now(), LastUsedAt: time.Now()}
+	p := testHostPool(conn)
+
+	const goroutines, iterations = 8, 250
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				conn.MarkUsed()
+			}
+		}()
+	}
+	// Both paths that used to touch the fields directly: the client's
+	// "is this connection new" timing branch, and HostPool.Stats.
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_ = conn.Uses() == 1
+				_ = conn.IdleTime()
+				p.Stats()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got, want := conn.Uses(), int64(goroutines*iterations); got != want {
+		t.Errorf("UseCount after concurrent MarkUsed: got %d, want %d", got, want)
+	}
+}
+
+func TestQUICConnUsesUnderConcurrentMarkUsed(t *testing.T) {
+	conn := &QUICConn{Host: "example.com", CreatedAt: time.Now(), LastUsedAt: time.Now()}
+	p := testQUICHostPool(conn)
+
+	const goroutines, iterations = 8, 250
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				conn.MarkUsed()
+			}
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_ = conn.Uses() == 1
+				_ = conn.IdleTime()
+				p.Stats()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got, want := conn.Uses(), int64(goroutines*iterations); got != want {
+		t.Errorf("UseCount after concurrent MarkUsed: got %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
`pool.(*Conn).MarkUsed()` writes `UseCount` under `c.mu`, and `GetConn` calls it on every connection it hands out. Three callers read the field back with no lock:

- `client/client.go:1425` — `doHTTP2`, `pool.Conn`
- `client/client.go:1389` — `doHTTP3`, `pool.QUICConn`
- `client/http3_client.go:113` — `HTTP3Client.Do`, `pool.QUICConn`

HTTP/2 and HTTP/3 multiplex, so two overlapping requests share one connection: one is inside the guarded write while the other reads bare. `HostPool.Stats` and `QUICHostPool.Stats` have the same hole, summing `UseCount` under `p.mu` only, which doesn't exclude `MarkUsed`.

The stakes are small — the value only decides whether connect time is split across the `Timing` fields or left at zero, so the damage is wrong timing attribution on a reused connection, never a wrong request. But it fails `-race` builds intermittently, roughly one run in four to eight, surfacing on `TestPoolReuseConcurrent`.

### Fix

A mutex-guarded `Uses() int64` on `Conn` and `QUICConn`, alongside the existing `IdleTime()`, with all five reads routed through it. Purely additive; nothing changes shape.

`LastUsedAt` needs no equivalent. `isConnUsable`/`isConnDestroyable` already snapshot it under `c.mu` in both pools, and the `transport` package's `useCount`/`lastUsedAt` are a different struct whose readers all take `conn.mu`.

### Verification

`pool/usecount_race_test.go` locks it down: 8 writers against 8 readers, exercising both the `Uses() == 1` timing branch and `Stats()`. Confirmed by reverting — dropping the mutex from `Uses()` fires `WARNING: DATA RACE` naming `MarkUsed` against `Uses` on the first run.

`go test -race -short ./client/ ./transport/ ./pool/ -count=3` green, and `TestPoolReuseConcurrent` green at `-count=25`.