### PR TITLE
feat(session): add CloseGraceful, closing a session without cutting off in-flight requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ internal_tests/
 !/local_proxy_gzip_test.go
 !/rootcas_verify_test.go
 !/redirect_test.go
+!/close_graceful_test.go
 
 # Local workspace config (points at machine-local fork paths)
 go.work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`Session.CloseGraceful` closes a session without cutting off requests still in flight**: `Close` tears the session's connections down at once, which is right for shutdown but wrong for rotating a long-lived session, because any response body still being read on one of its connections is interrupted with "use of closed network connection". Anyone rotating sessions therefore had to guess a grace period longer than their longest possible request and sleep it out before calling `Close`. `CloseGraceful` stops the session taking new requests immediately (they fail with `ErrSessionClosed`, exactly as after `Close`), closes every idle connection now, and lets each connection that still has a response streaming on it finish that response first, closing it the moment the body is done. It returns without waiting; the draining happens in the background. This reuses the deferred close that 1.6.9 introduced for #83, applied to the whole HTTP/2 pool instead of to one evicted connection, and the pool's cleanup pass keeps running until the last such connection is gone so that a body which is never closed is still reclaimed by the abandoned-body bound rather than pinning its socket. HTTP/1.1 connections are only ever closed while idle, so they already behaved this way; HTTP/3 connections are closed immediately, as by `Close`, since the QUIC layer has no per-request drain. `Close` after `CloseGraceful` is not a no-op: it forces whatever is still draining. `Close` itself is unchanged.
+
 ## [1.6.11] - 2026-08-17
 
 ### Added

--- a/close_graceful_test.go
+++ b/close_graceful_test.go
@@ -1,0 +1,118 @@
+package httpcloak
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sardanioss/httpcloak/session"
+)
+
+// Session.CloseGraceful through the public API: a streamed response that is
+// mid-body when the session is closed gracefully is delivered in full, the
+// session refuses new requests from that moment, and Close afterwards is still
+// available to force anything left draining.
+func TestSessionCloseGracefulKeepsStreamingBody(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "first-")
+		w.(http.Flusher).Flush()
+		close(started)
+		<-release
+		io.WriteString(w, "second")
+	}))
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+	defer srv.Close()
+
+	s := NewSession("chrome-latest", WithForceHTTP2(), WithInsecureSkipVerify())
+	defer s.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	stream, err := s.DoStream(ctx, &Request{Method: http.MethodGet, URL: srv.URL})
+	if err != nil {
+		t.Fatalf("DoStream: %v", err)
+	}
+	if stream.Protocol != "h2" {
+		t.Fatalf("expected an HTTP/2 stream, got %q", stream.Protocol)
+	}
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server never flushed the first half of the body")
+	}
+
+	s.CloseGraceful()
+
+	if s.IsActive() {
+		t.Error("session should be inactive after CloseGraceful")
+	}
+	if _, err := s.Get(ctx, srv.URL); !errors.Is(err, session.ErrSessionClosed) {
+		t.Errorf("Get after CloseGraceful: got %v, want ErrSessionClosed", err)
+	}
+
+	close(release)
+	type result struct {
+		b   []byte
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		b, err := stream.ReadAll()
+		done <- result{b, err}
+	}()
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatalf("reading the stream after CloseGraceful: %v", res.err)
+		}
+		if got, want := string(res.b), "first-second"; got != want {
+			t.Fatalf("stream body after CloseGraceful = %q, want %q", got, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("stream did not finish within 5s after CloseGraceful")
+	}
+	stream.Close()
+
+	// Close after CloseGraceful is the hard close, and is safe to repeat.
+	s.Close()
+	s.Close()
+	s.CloseGraceful()
+}
+
+// Close after CloseGraceful runs the transport's hard close a second time. On a
+// default session that means every sub-transport, HTTP/3 included, has to take
+// a repeated Close; pin that it does, in both orders and repeatedly.
+func TestSessionCloseGracefulThenCloseIsSafe(t *testing.T) {
+	t.Run("auto protocol", func(t *testing.T) {
+		s := NewSession("chrome-latest")
+		s.CloseGraceful()
+		s.Close()
+		s.Close()
+		s.CloseGraceful()
+		if s.IsActive() {
+			t.Error("session should be inactive")
+		}
+	})
+	t.Run("close then graceful", func(t *testing.T) {
+		s := NewSession("chrome-latest")
+		s.Close()
+		s.CloseGraceful()
+		s.Close()
+		if s.IsActive() {
+			t.Error("session should be inactive")
+		}
+	})
+	t.Run("forced h3", func(t *testing.T) {
+		s := NewSession("chrome-latest", WithForceHTTP3())
+		s.CloseGraceful()
+		s.Close()
+	})
+}

--- a/docs/docs/bindings/go.md
+++ b/docs/docs/bindings/go.md
@@ -136,13 +136,15 @@ Streaming won't auto-follow redirects. A 3xx on a stream response has to be hand
 
 ```go
 func (s *Session) Close()
+func (s *Session) CloseGraceful()
 func (s *Session) Refresh()
 func (s *Session) RefreshWithProtocol(protocol string) error
 func (s *Session) Warmup(ctx context.Context, url string) error
 func (s *Session) Fork(n int) []*Session
 ```
 
-- `Close()` releases the connection pool and the cookie jar. Always defer it.
+- `Close()` releases the connection pool and the cookie jar. Always defer it. It closes every connection at once, so a response body another goroutine is still reading is interrupted.
+- `CloseGraceful()` is `Close()` for rotating a session that other goroutines may still be reading from: it refuses new requests immediately, closes idle connections now, and lets a connection that still has a response body streaming on it finish that body first, then closes it. It returns without waiting. Calling `Close()` afterwards forces whatever is still draining, so keep the deferred `Close()` only if you want that. HTTP/1.1 and HTTP/2 drain like this; HTTP/3 connections close immediately either way.
 - `Refresh()` drops connections but keeps cookies and TLS tickets, mirroring a browser F5.
 - `RefreshWithProtocol("h1" | "h2" | "h3" | "auto")` does a refresh and switches the wire protocol for following requests. Useful for warming TLS on H3 and then serving H2 with resumption.
 - `Warmup(ctx, url)` runs a browser-style page load: HTML first, then subresources with proper priorities, headers, and timing. Pop it before hitting an antibot endpoint.

--- a/docs/docs/connection-lifecycle/observability.md
+++ b/docs/docs/connection-lifecycle/observability.md
@@ -38,7 +38,7 @@ The fields:
 | `CreatedAt` | `time.Time` | Wall-clock time when `NewSession` returned. |
 | `LastUsed` | `time.Time` | Wall-clock time of the last request *start* (or explicit `Touch()`). Set at the top of `Do` / `DoStream` / `Warmup`, not on exit, so a long-running streaming request keeps `IdleTime()` near zero for its whole duration rather than only after the body finishes. |
 | `RequestCount` | `int64` | Total request count since creation. Counts every request that left the session, including failed ones. |
-| `Active` | `bool` | False after `Close()` returns. Same value `IsActive()` reports. |
+| `Active` | `bool` | False after `Close()` or `CloseGraceful()` returns. Same value `IsActive()` reports. |
 | `CookieCount` | `int` | Number of cookies in the jar at snapshot time. |
 | `CacheEntryCount` | `int` | Number of conditional-request cache entries (one per URL with an ETag or Last-Modified seen). |
 | `Age` | `time.Duration` | `time.Since(CreatedAt)`. |
@@ -88,7 +88,7 @@ sess.Touch()  // reset idle clock; request count is unchanged
 
 ### IsActive
 
-`IsActive()` returns `false` once `Close()` has run, `true` otherwise. The flag is set during `Close()` under the same lock that guards every other session operation, so a `true` result means the session can still service a new request, and a `false` result is permanent (closed sessions don't reopen, build a new one with `NewSession`). Use it as a guard at the top of code paths that share a session pointer across goroutines or worker tasks.
+`IsActive()` returns `false` once `Close()` or `CloseGraceful()` has run, `true` otherwise. The flag is set during the close under the same lock that guards every other session operation, so a `true` result means the session can still service a new request, and a `false` result is permanent (closed sessions don't reopen, build a new one with `NewSession`). Use it as a guard at the top of code paths that share a session pointer across goroutines or worker tasks.
 
 ```go
 if !sess.IsActive() {

--- a/docs/docs/recipes/long-running-scraper-patterns.md
+++ b/docs/docs/recipes/long-running-scraper-patterns.md
@@ -318,6 +318,7 @@ Tune the cadences to the target. A scraper hammering one host per second wants l
 - **Don't save state on every request.** Disk IO ends up dominating. Every few minutes is plenty.
 - **Don't share one session across very different targets.** Cookies in the jar are scoped per-host, but session-level state (TLS tickets, ECH config) crosses targets. One session per target keeps everything tidy.
 - **Don't forget `resp.Close()`.** Body leaks tie up connection resources and make `Refresh()` less effective, since the connection it would have dropped is still bound to a leaked body.
+- **Don't `Close()` a session other goroutines are still reading from.** `Close()` drops every connection at once, so a worker halfway through a response body gets "use of closed network connection". When you retire a live session (rotating identities, swapping proxies), call `CloseGraceful()` instead: it refuses new requests immediately and lets each in-flight body finish before its connection goes away.
 
 ## Forking sessions for parallel scrapes
 

--- a/httpcloak.go
+++ b/httpcloak.go
@@ -1399,9 +1399,23 @@ func (s *Session) Fork(n int) []*Session {
 	return forks
 }
 
-// Close closes the session and releases resources
+// Close closes the session and releases resources immediately. Any request
+// still in flight, including a body still being read, is interrupted.
 func (s *Session) Close() {
 	s.inner.Close()
+}
+
+// CloseGraceful closes the session without interrupting requests that are in
+// flight. The session stops accepting new requests at once; idle connections
+// close now, and a connection still delivering a response body closes when that
+// body is finished. It returns immediately, and calling Close afterwards forces
+// anything still draining. This is the right call when retiring a long-lived
+// session that other goroutines may still be reading responses from.
+//
+// HTTP/1.1 and HTTP/2 connections drain as described. HTTP/3 connections are
+// closed immediately, as by Close.
+func (s *Session) CloseGraceful() {
+	s.inner.CloseGraceful()
 }
 
 // Refresh closes all connections but keeps TLS session caches and cookies intact.

--- a/session/session.go
+++ b/session/session.go
@@ -102,6 +102,11 @@ type Session struct {
 	// Key log writer for TLS traffic decryption (Wireshark)
 	keyLogWriter io.WriteCloser
 
+	// draining is set by CloseGraceful: the session is inactive but its
+	// transport may still hold connections finishing in-flight responses, so a
+	// later Close must still reach the transport to force them.
+	draining bool
+
 	// refreshed indicates Refresh() was called - adds cache-control: max-age=0 to requests
 	refreshed bool
 
@@ -1218,8 +1223,30 @@ func (s *Session) IsActive() bool {
 	return s.active
 }
 
-// Close marks the session as inactive and closes connections
+// Close marks the session as inactive and closes connections immediately,
+// including any left draining by an earlier CloseGraceful.
 func (s *Session) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.active && !s.draining {
+		return
+	}
+	s.active = false
+	s.draining = false
+
+	if s.transport != nil {
+		s.transport.Close()
+	}
+	s.closeKeyLog()
+}
+
+// CloseGraceful marks the session as inactive and closes its connections
+// without interrupting requests that are in flight: idle connections close
+// now, and a connection with a response body still streaming closes when the
+// body finishes. It returns immediately. Close may be called afterwards to
+// force whatever is still draining.
+func (s *Session) CloseGraceful() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -1227,12 +1254,17 @@ func (s *Session) Close() {
 		return
 	}
 	s.active = false
+	s.draining = true
 
 	if s.transport != nil {
-		s.transport.Close()
+		s.transport.CloseGraceful()
 	}
+	// No handshake happens after this point, so nothing more is logged.
+	s.closeKeyLog()
+}
 
-	// Close key log writer if we opened one
+// closeKeyLog closes the key log writer if we opened one. Caller holds s.mu.
+func (s *Session) closeKeyLog() {
 	if s.keyLogWriter != nil {
 		s.keyLogWriter.Close()
 		s.keyLogWriter = nil

--- a/transport/close_graceful_e2e_test.go
+++ b/transport/close_graceful_e2e_test.go
@@ -1,0 +1,423 @@
+package transport
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	http "github.com/sardanioss/http"
+	"github.com/sardanioss/httpcloak/dns"
+	"github.com/sardanioss/httpcloak/fingerprint"
+)
+
+// End-to-end check of CloseGraceful against a real HTTP/2 server: a response
+// body that is mid-stream when the transport is closed gracefully is delivered
+// in full, the transport refuses new requests from that moment, and the
+// connection closes once the body is done. The same scenario under Close is
+// included for contrast, so the two behaviours are pinned side by side.
+
+// slowH2Server serves one response whose body arrives in two halves: the first
+// half at once, the second only after release is closed.
+type slowH2Server struct {
+	srv     *httptest.Server
+	host    string
+	port    string
+	started chan struct{} // closed once the first half has been flushed
+	release chan struct{} // close to let the handler send the second half
+}
+
+const (
+	slowBodyFirstHalf  = "first-half-"
+	slowBodySecondHalf = "second-half"
+)
+
+func newSlowH2Server(t *testing.T) *slowH2Server {
+	t.Helper()
+	s := &slowH2Server{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	s.srv = httptest.NewUnstartedServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		if r.ProtoMajor != 2 {
+			stdhttp.Error(w, "expected HTTP/2, got "+r.Proto, stdhttp.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(stdhttp.StatusOK)
+		io.WriteString(w, slowBodyFirstHalf)
+		w.(stdhttp.Flusher).Flush()
+		close(s.started)
+		<-s.release
+		io.WriteString(w, slowBodySecondHalf)
+	}))
+	s.srv.EnableHTTP2 = true
+	s.srv.StartTLS()
+	t.Cleanup(s.srv.Close)
+
+	u, err := url.Parse(s.srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.host, s.port, err = net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func (s *slowH2Server) request(t *testing.T) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, s.srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return req
+}
+
+func newE2ETransport(t *testing.T) *HTTP2Transport {
+	t.Helper()
+	preset := fingerprint.Get("chrome-146")
+	if preset == nil {
+		t.Skip("chrome-146 preset unavailable")
+	}
+	tr := NewHTTP2Transport(preset, dns.NewCache())
+	tr.SetInsecureSkipVerify(true)
+	t.Cleanup(tr.Close)
+	return tr
+}
+
+// readWithin reads r to EOF in the background and fails the test if that does
+// not finish within d, so a body that hangs is reported rather than blocking.
+func readWithin(t *testing.T, r io.Reader, d time.Duration) ([]byte, error) {
+	t.Helper()
+	type result struct {
+		b   []byte
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		b, err := io.ReadAll(r)
+		done <- result{b, err}
+	}()
+	select {
+	case res := <-done:
+		return res.b, res.err
+	case <-time.After(d):
+		t.Fatalf("reading the response body did not finish within %s", d)
+		return nil, nil
+	}
+}
+
+func TestCloseGracefulE2E(t *testing.T) {
+	srv := newSlowH2Server(t)
+	tr := newE2ETransport(t)
+
+	resp, err := tr.RoundTrip(srv.request(t))
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	if resp.ProtoMajor != 2 {
+		t.Fatalf("expected an HTTP/2 response, got %s", resp.Proto)
+	}
+	select {
+	case <-srv.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server never flushed the first half of the body")
+	}
+
+	// The connection carrying the response, so we can watch it after it leaves
+	// the pool.
+	key := net.JoinHostPort(srv.host, srv.port)
+	tr.connsMu.RLock()
+	conn := tr.conns[key]
+	tr.connsMu.RUnlock()
+	if conn == nil {
+		t.Fatalf("no pooled connection for %s", key)
+	}
+
+	tr.CloseGraceful()
+
+	// From here on: no new requests ...
+	if _, err := tr.RoundTrip(srv.request(t)); err == nil {
+		t.Error("RoundTrip after CloseGraceful should fail")
+	} else if !strings.Contains(err.Error(), "closed") {
+		t.Errorf("RoundTrip after CloseGraceful: got %v, want a closed error", err)
+	}
+	// ... but the response in flight is untouched.
+	if connClosed(conn)() {
+		t.Fatal("CloseGraceful closed the connection under a body still streaming")
+	}
+	if n := retiredCount(tr); n != 1 {
+		t.Fatalf("streaming connection should be retired, got %d retired", n)
+	}
+
+	// Let the server finish; the reader gets the whole body with no error.
+	close(srv.release)
+	body, err := readWithin(t, resp.Body, 5*time.Second)
+	if err != nil {
+		t.Fatalf("reading body after CloseGraceful: %v", err)
+	}
+	if got, want := string(body), slowBodyFirstHalf+slowBodySecondHalf; got != want {
+		t.Fatalf("body after CloseGraceful = %q, want %q", got, want)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("Body.Close: %v", err)
+	}
+
+	// And now, with the body done, the connection goes away on its own.
+	if !waitFor(t, 2*time.Second, connClosed(conn)) {
+		t.Error("connection did not close after its last body finished")
+	}
+	tr.cleanup()
+	if !tr.drained() {
+		t.Error("transport should be drained once the last body finished")
+	}
+}
+
+// The behaviour CloseGraceful exists to avoid: Close cuts the reader off.
+func TestCloseInterruptsStreamingBodyE2E(t *testing.T) {
+	srv := newSlowH2Server(t)
+	tr := newE2ETransport(t)
+
+	resp, err := tr.RoundTrip(srv.request(t))
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	select {
+	case <-srv.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server never flushed the first half of the body")
+	}
+
+	tr.Close()
+	defer close(srv.release) // let the handler return so the server can shut down
+
+	body, err := readWithin(t, resp.Body, 5*time.Second)
+	if err == nil {
+		t.Fatalf("Close should have interrupted the body read; got a clean %q", body)
+	}
+	if errors.Is(err, io.EOF) {
+		t.Fatal("Close should surface an error to the reader, not a clean EOF")
+	}
+}
+
+// Session-level shape of the same guarantee, through Transport.CloseGraceful:
+// DoStream's body outlives the call, so it is the reader most likely to be cut
+// off by a rotation.
+func TestTransportCloseGracefulStreamE2E(t *testing.T) {
+	srv := newSlowH2Server(t)
+	if fingerprint.Get("chrome-146") == nil {
+		t.Skip("chrome-146 preset unavailable")
+	}
+	tr := NewTransport("chrome-146")
+	tr.SetInsecureSkipVerify(true)
+	tr.SetProtocol(ProtocolHTTP2)
+	t.Cleanup(tr.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	stream, err := tr.DoStream(ctx, &Request{Method: http.MethodGet, URL: srv.srv.URL})
+	if err != nil {
+		t.Fatalf("DoStream: %v", err)
+	}
+	select {
+	case <-srv.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server never flushed the first half of the body")
+	}
+
+	tr.CloseGraceful()
+
+	if _, err := tr.Do(ctx, &Request{Method: http.MethodGet, URL: srv.srv.URL}); err == nil {
+		t.Error("Do after CloseGraceful should fail")
+	}
+
+	close(srv.release)
+	body, err := readWithin(t, stream, 5*time.Second)
+	if err != nil {
+		t.Fatalf("reading stream after CloseGraceful: %v", err)
+	}
+	if got, want := string(body), slowBodyFirstHalf+slowBodySecondHalf; got != want {
+		t.Fatalf("stream body after CloseGraceful = %q, want %q", got, want)
+	}
+	stream.Close()
+}
+
+// The rotation case: a plain Do that is still reading its response when the
+// transport is closed gracefully returns the full response, not an error.
+func TestTransportCloseGracefulDoInFlightE2E(t *testing.T) {
+	srv := newSlowH2Server(t)
+	if fingerprint.Get("chrome-146") == nil {
+		t.Skip("chrome-146 preset unavailable")
+	}
+	tr := NewTransport("chrome-146")
+	tr.SetInsecureSkipVerify(true)
+	tr.SetProtocol(ProtocolHTTP2)
+	t.Cleanup(tr.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	type result struct {
+		resp *Response
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		resp, err := tr.Do(ctx, &Request{Method: http.MethodGet, URL: srv.srv.URL})
+		done <- result{resp, err}
+	}()
+	select {
+	case <-srv.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server never flushed the first half of the body")
+	}
+
+	tr.CloseGraceful()
+	close(srv.release)
+
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatalf("Do in flight across CloseGraceful: %v", res.err)
+		}
+		body, err := io.ReadAll(res.resp.Body)
+		if err != nil {
+			t.Fatalf("reading Do body: %v", err)
+		}
+		if got, want := string(body), slowBodyFirstHalf+slowBodySecondHalf; got != want {
+			t.Fatalf("Do body across CloseGraceful = %q, want %q", got, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Do did not return within 5s of the server finishing")
+	}
+}
+
+// Same hammer as TestH2TransportConcurrentCloseAndRoundTrip, for the graceful
+// path: dials racing a CloseGraceful must neither panic nor leak a connection
+// that was published after the transport closed.
+func TestH2TransportConcurrentCloseGracefulAndDial(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping race stress in short mode")
+	}
+	preset := fingerprint.Get("chrome-146")
+	if preset == nil {
+		t.Skip("chrome-146 preset unavailable")
+	}
+
+	srv := httptest.NewUnstartedServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		w.WriteHeader(stdhttp.StatusOK)
+	}))
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+	defer srv.Close()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port, _ := net.SplitHostPort(u.Host)
+	key := net.JoinHostPort(host, port)
+
+	const (
+		iterations = 30
+		goroutines = 16
+	)
+	for i := 0; i < iterations; i++ {
+		tr := NewHTTP2Transport(preset, dns.NewCache())
+		tr.SetInsecureSkipVerify(true)
+
+		var wg sync.WaitGroup
+		for g := 0; g < goroutines; g++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						t.Errorf("panicked: %v", r)
+					}
+				}()
+				ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+				defer cancel()
+				_, _ = tr.getOrCreateConn(ctx, host, port, key)
+			}()
+		}
+		time.Sleep(time.Duration(i%10) * 100 * time.Microsecond)
+		tr.CloseGraceful()
+		wg.Wait()
+
+		// Whatever the interleaving, nothing may remain in the pool: a dial
+		// that lost the race to CloseGraceful must have closed its connection.
+		tr.connsMu.RLock()
+		leaked := len(tr.conns)
+		tr.connsMu.RUnlock()
+		if leaked != 0 {
+			t.Fatalf("iteration %d: %d connection(s) published into a gracefully closed transport", i, leaked)
+		}
+		tr.Close()
+	}
+}
+
+// HTTP/1.1 gets the same guarantee through Transport.CloseGraceful without any
+// H1-specific code: its transport only ever closes idle connections, and a
+// checked-out one closes itself on return once the transport is closed. This
+// pins that, so a change to the H1 pool cannot silently break the contract.
+func TestTransportCloseGracefulH1StreamE2E(t *testing.T) {
+	if fingerprint.Get("chrome-146") == nil {
+		t.Skip("chrome-146 preset unavailable")
+	}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	// NewTLSServer negotiates http/1.1 only.
+	srv := httptest.NewTLSServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		w.WriteHeader(stdhttp.StatusOK)
+		io.WriteString(w, slowBodyFirstHalf)
+		w.(stdhttp.Flusher).Flush()
+		close(started)
+		<-release
+		io.WriteString(w, slowBodySecondHalf)
+	}))
+	defer srv.Close()
+
+	tr := NewTransport("chrome-146")
+	tr.SetInsecureSkipVerify(true)
+	tr.SetProtocol(ProtocolHTTP1)
+	t.Cleanup(tr.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	stream, err := tr.DoStream(ctx, &Request{Method: http.MethodGet, URL: srv.URL})
+	if err != nil {
+		t.Fatalf("DoStream: %v", err)
+	}
+	if stream.Protocol != "h1" {
+		t.Fatalf("expected an HTTP/1.1 stream, got %q", stream.Protocol)
+	}
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server never flushed the first half of the body")
+	}
+
+	tr.CloseGraceful()
+
+	if _, err := tr.Do(ctx, &Request{Method: http.MethodGet, URL: srv.URL}); err == nil {
+		t.Error("Do after CloseGraceful should fail")
+	}
+
+	close(release)
+	body, err := readWithin(t, stream, 5*time.Second)
+	if err != nil {
+		t.Fatalf("reading H1 stream after CloseGraceful: %v", err)
+	}
+	if got, want := string(body), slowBodyFirstHalf+slowBodySecondHalf; got != want {
+		t.Fatalf("H1 stream body after CloseGraceful = %q, want %q", got, want)
+	}
+	stream.Close()
+}

--- a/transport/close_graceful_test.go
+++ b/transport/close_graceful_test.go
@@ -1,0 +1,232 @@
+package transport
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Tests for HTTP2Transport.CloseGraceful.
+//
+// Close tears the transport down immediately, which is right for shutdown but
+// wrong for rotating a long-lived session: any response body still being read
+// on one of its connections is cut off. The deferred close that #83 introduced
+// (requestClose / retire) already knows how to let a busy connection finish
+// first; CloseGraceful is that primitive applied to the whole transport.
+//
+// These lock the contract at the transport layer with fake connections, in the
+// same style as the #83 tests. close_graceful_e2e_test.go drives the same path
+// through a real HTTP/2 server.
+
+// waitFor polls cond until it holds or the deadline passes. Socket closes are
+// fired off the caller's goroutine, so tests observing conn.closed must wait.
+func waitFor(t *testing.T, d time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return cond()
+}
+
+func connClosed(conn *persistentConn) func() bool {
+	return func() bool {
+		conn.mu.Lock()
+		defer conn.mu.Unlock()
+		return conn.closed
+	}
+}
+
+func cleanupStopped(tr *HTTP2Transport) bool {
+	select {
+	case <-tr.stopCleanup:
+		return true
+	default:
+		return false
+	}
+}
+
+func retiredCount(tr *HTTP2Transport) int {
+	tr.retiredMu.Lock()
+	defer tr.retiredMu.Unlock()
+	return len(tr.retired)
+}
+
+// A connection with nothing on it closes right away, and with nothing left to
+// drain the cleanup loop is released too.
+func TestCloseGracefulClosesIdleConnNow(t *testing.T) {
+	tr := testTransport(t)
+
+	conn := streamingConn(0, time.Second, -1)
+	tr.connsMu.Lock()
+	tr.conns["example.com:443"] = conn
+	tr.connsMu.Unlock()
+
+	tr.CloseGraceful()
+
+	if !waitFor(t, time.Second, connClosed(conn)) {
+		t.Error("an idle connection should close as soon as CloseGraceful runs")
+	}
+	if n := retiredCount(tr); n != 0 {
+		t.Errorf("an idle connection was tracked as retired (%d), it should simply close", n)
+	}
+	if !cleanupStopped(tr) {
+		t.Error("with nothing left to drain, CloseGraceful should stop the cleanup loop")
+	}
+	if !tr.drained() {
+		t.Error("transport should report drained")
+	}
+}
+
+// The core of the feature: a connection with a response body still streaming
+// is not closed under the reader. It is retired, keeps working until the body
+// finishes, and only then closes.
+func TestCloseGracefulDefersStreamingConn(t *testing.T) {
+	tr := testTransport(t)
+
+	conn := streamingConn(1, time.Second, 50*time.Millisecond)
+	tr.connsMu.Lock()
+	tr.conns["example.com:443"] = conn
+	tr.connsMu.Unlock()
+
+	tr.CloseGraceful()
+
+	conn.mu.Lock()
+	deferred := conn.closeRequested
+	closed := conn.closed
+	conn.mu.Unlock()
+	if closed {
+		t.Fatal("CloseGraceful closed a connection that still had a body streaming on it")
+	}
+	if !deferred {
+		t.Error("a streaming connection should have its close deferred, not skipped")
+	}
+	if n := retiredCount(tr); n != 1 {
+		t.Fatalf("streaming connection tracked in retired: got %d, want 1", n)
+	}
+	if cleanupStopped(tr) {
+		t.Error("cleanup loop was stopped while a connection is still draining; " +
+			"nothing would apply the abandoned-body bound to it")
+	}
+	if tr.drained() {
+		t.Error("transport reported drained while a connection is still draining")
+	}
+
+	// New work is refused from the moment CloseGraceful returns.
+	tr.connsMu.RLock()
+	conns := tr.conns
+	tr.connsMu.RUnlock()
+	if conns != nil {
+		t.Error("CloseGraceful should have taken every connection out of the pool")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	if _, err := tr.getOrCreateConn(ctx, "example.com", "443", "example.com:443"); err == nil {
+		t.Error("getOrCreateConn after CloseGraceful should fail")
+	} else if !strings.Contains(err.Error(), "closed") {
+		t.Errorf("getOrCreateConn after CloseGraceful: got %v, want a closed error", err)
+	}
+
+	// The body finishing is what fires the close.
+	conn.release()
+	if !waitFor(t, time.Second, connClosed(conn)) {
+		t.Fatal("finishing the last in-flight request should close the retired connection")
+	}
+
+	// And the next cleanup pass forgets it and lets the loop exit.
+	tr.cleanup()
+	if n := retiredCount(tr); n != 0 {
+		t.Errorf("sweep left %d drained connections tracked, want 0", n)
+	}
+	if !tr.drained() {
+		t.Error("transport should report drained once the last retired connection is gone")
+	}
+}
+
+// A body that is never closed must not pin its socket past CloseGraceful. The
+// cleanup loop keeps running for exactly this reason: the abandoned-body bound
+// has to reach connections left draining.
+func TestCloseGracefulStillReclaimsAbandonedBody(t *testing.T) {
+	tr := testTransport(t)
+
+	conn := streamingConn(1, 30*time.Minute, tr.abandonedBodyTimeout+time.Minute)
+	tr.connsMu.Lock()
+	tr.conns["example.com:443"] = conn
+	tr.connsMu.Unlock()
+
+	tr.CloseGraceful()
+
+	if n := retiredCount(tr); n != 1 {
+		t.Fatalf("expected the abandoned connection to be draining, got %d retired", n)
+	}
+	if cleanupStopped(tr) {
+		t.Fatal("cleanup loop stopped with a connection still draining")
+	}
+
+	// What the loop does on its next tick.
+	tr.cleanup()
+
+	if !waitFor(t, time.Second, connClosed(conn)) {
+		t.Error("the abandoned-body bound never reached a connection left draining by CloseGraceful")
+	}
+	if n := retiredCount(tr); n != 0 {
+		t.Errorf("sweep left %d connections tracked, want 0", n)
+	}
+	if !tr.drained() {
+		t.Error("transport should report drained after the abandoned body was reclaimed")
+	}
+}
+
+// Close after CloseGraceful is not a no-op: it forces whatever is still
+// draining, exactly as it would have without the graceful step.
+func TestCloseAfterCloseGracefulForcesDraining(t *testing.T) {
+	tr := testTransport(t)
+
+	conn := streamingConn(1, time.Second, 50*time.Millisecond)
+	tr.connsMu.Lock()
+	tr.conns["example.com:443"] = conn
+	tr.connsMu.Unlock()
+
+	tr.CloseGraceful()
+	if connClosed(conn)() {
+		t.Fatal("precondition: connection should be draining, not closed")
+	}
+
+	tr.Close()
+
+	if !waitFor(t, time.Second, connClosed(conn)) {
+		t.Error("Close after CloseGraceful left a draining connection open")
+	}
+	if n := retiredCount(tr); n != 0 {
+		t.Errorf("Close left %d retired connections tracked, want 0", n)
+	}
+	if !cleanupStopped(tr) {
+		t.Error("Close should stop the cleanup loop")
+	}
+}
+
+// Both orders of the two calls, and repeats of each, are safe.
+func TestCloseGracefulIdempotent(t *testing.T) {
+	t.Run("graceful twice then close", func(t *testing.T) {
+		tr := testTransport(t)
+		tr.CloseGraceful()
+		tr.CloseGraceful()
+		tr.Close()
+		tr.Close()
+		if !cleanupStopped(tr) {
+			t.Error("cleanup loop should be stopped")
+		}
+	})
+	t.Run("close then graceful", func(t *testing.T) {
+		tr := testTransport(t)
+		tr.Close()
+		tr.CloseGraceful()
+		if !cleanupStopped(tr) {
+			t.Error("cleanup loop should be stopped")
+		}
+	})
+}

--- a/transport/http2_transport.go
+++ b/transport/http2_transport.go
@@ -73,8 +73,11 @@ type HTTP2Transport struct {
 	localAddr            string // Local IP to bind outgoing connections
 
 	// Cleanup
-	stopCleanup chan struct{}
-	closed      bool
+	stopCleanup     chan struct{}
+	stopCleanupOnce sync.Once
+	// closed means the transport takes no new requests. Set by both Close and
+	// CloseGraceful; the latter leaves connections draining in t.retired.
+	closed bool
 }
 
 // persistentConn represents a persistent HTTP/2 connection
@@ -148,7 +151,9 @@ func (t *HTTP2Transport) retire(conn *persistentConn) {
 	conn.mu.Unlock()
 
 	if !deferred {
-		conn.close()
+		// Off the caller's goroutine, like every other shutdown path here: a
+		// TLS close can stall for up to 250ms on an unresponsive peer.
+		go conn.close()
 		return
 	}
 
@@ -1296,7 +1301,11 @@ func (c *persistentConn) close() {
 	}
 }
 
-// cleanupLoop periodically cleans up stale connections
+// cleanupLoop periodically cleans up stale connections. After CloseGraceful it
+// keeps running until the last retired connection has drained, because it is
+// the only thing that applies the abandoned-body bound to those connections;
+// stopping it at CloseGraceful would let a body that is never closed pin its
+// socket for the process lifetime.
 func (t *HTTP2Transport) cleanupLoop() {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
@@ -1307,8 +1316,25 @@ func (t *HTTP2Transport) cleanupLoop() {
 			return
 		case <-ticker.C:
 			t.cleanup()
+			if t.drained() {
+				return
+			}
 		}
 	}
+}
+
+// drained reports whether a closed transport has nothing left to reclaim, i.e.
+// no connection is still deferring its close behind a streaming body.
+func (t *HTTP2Transport) drained() bool {
+	t.connsMu.RLock()
+	closed := t.closed
+	t.connsMu.RUnlock()
+	if !closed {
+		return false
+	}
+	t.retiredMu.Lock()
+	defer t.retiredMu.Unlock()
+	return len(t.retired) == 0
 }
 
 // cleanup removes stale connections
@@ -1330,32 +1356,63 @@ func (t *HTTP2Transport) cleanup() {
 	t.sweepRetired()
 }
 
-// Close shuts down the transport
+// Close shuts down the transport immediately. Every connection is closed,
+// including ones with a response body still streaming and ones left draining by
+// an earlier CloseGraceful.
 func (t *HTTP2Transport) Close() {
 	t.connsMu.Lock()
-	defer t.connsMu.Unlock()
-
-	if t.closed {
-		return
-	}
 	t.closed = true
+	conns := t.conns
+	t.conns = nil
+	t.connsMu.Unlock()
 
-	close(t.stopCleanup)
+	t.stopCleanupOnce.Do(func() { close(t.stopCleanup) })
 
-	for _, conn := range t.conns {
+	for _, conn := range conns {
 		go conn.close()
 	}
-	t.conns = nil
 
 	// Connections evicted while still streaming are not in t.conns. Shutdown is
 	// unconditional, so close them here too rather than leaving their sockets
 	// behind after the transport is gone.
 	t.retiredMu.Lock()
-	for _, conn := range t.retired {
-		go conn.close()
-	}
+	retired := t.retired
 	t.retired = nil
 	t.retiredMu.Unlock()
+	for _, conn := range retired {
+		go conn.close()
+	}
+}
+
+// CloseGraceful shuts down the transport without interrupting requests that are
+// in flight. It stops taking new requests, closes every idle connection now, and
+// retires each connection that still has a response body streaming on it so it
+// closes when that body finishes (or when the abandoned-body bound reclaims it,
+// should the caller never close the body). It returns immediately; the draining
+// connections are reclaimed in the background. Close may be called afterwards
+// to force whatever is still draining.
+func (t *HTTP2Transport) CloseGraceful() {
+	t.connsMu.Lock()
+	if t.closed {
+		t.connsMu.Unlock()
+		return
+	}
+	t.closed = true
+	conns := t.conns
+	t.conns = nil
+	t.connsMu.Unlock()
+
+	// retire, not requestClose: a connection whose close is deferred must stay
+	// tracked in t.retired so the cleanup loop can still bound it.
+	for _, conn := range conns {
+		t.retire(conn)
+	}
+
+	// Nothing left draining, so the cleanup loop has nothing to do; otherwise it
+	// runs on and exits itself once the last retired connection is gone.
+	if t.drained() {
+		t.stopCleanupOnce.Do(func() { close(t.stopCleanup) })
+	}
 }
 
 // Refresh closes all connections but keeps the TLS session cache intact.

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -2341,6 +2341,23 @@ func (t *Transport) Close() {
 	t.h3Transport.Close()
 }
 
+// CloseGraceful closes the transport without interrupting requests that are in
+// flight: no new request is accepted, idle connections close now, and a
+// connection still carrying a response closes once that response's body is
+// done. It returns immediately.
+//
+// HTTP/1.1 connections are only ever closed while idle, so an in-flight one is
+// untouched and closes when its body is finished. HTTP/2 connections with a
+// body still streaming are retired and close when the body finishes, or when
+// the abandoned-body bound reclaims one that is never closed. HTTP/3
+// connections are closed immediately, as by Close: the QUIC layer has no
+// per-request drain.
+func (t *Transport) CloseGraceful() {
+	t.h1Transport.Close()
+	t.h2Transport.CloseGraceful()
+	t.h3Transport.Close()
+}
+
 // Refresh closes all connections but keeps TLS session caches intact.
 // This simulates a browser page refresh - new TCP/QUIC connections but TLS resumption.
 // Useful for resetting connection state without losing session tickets.


### PR DESCRIPTION
## Problem

`Session.Close` tears the session's connections down at once. That is right for shutdown and wrong for rotation: a long-lived session that is being replaced usually still has a request or two on it, and `Close` interrupts them, so the reader sees `use of closed network connection` mid-body. Anyone rotating sessions today has to guess a grace period longer than their longest possible request and sleep it out before calling `Close`.

The primitive that avoids exactly this has existed since #83: `persistentConn.requestClose` / `HTTP2Transport.retire` defer a connection's close until its last in-flight response body is done. It is only ever applied to one evicted connection at a time. This PR applies it to the whole pool.

## What it adds

`Session.CloseGraceful()` at every layer (root, `session`, `transport.Transport`, `HTTP2Transport`):

- marks the session inactive, so new requests fail with `ErrSessionClosed` exactly as after `Close`;
- takes every connection out of the HTTP/2 pool and retires it: idle ones close now, ones with a body still streaming close when `release()` fires at the end of that body;
- returns immediately. Nothing waits on the drain.

`Close()` after `CloseGraceful()` is not a no-op: it hard-closes whatever is still draining (the `http.Server.Shutdown` / `Close` idiom), and it is safe to repeat in either order.

`Close` itself is unchanged in behaviour. Nothing on the wire changes. Nothing changes for anyone who does not call the new method.

## Design notes

- **The cleanup loop is deliberately not stopped at `CloseGraceful`.** It is the only thing that applies the abandoned-body bound (10 min without a byte) to retired connections, so stopping it would let a body that is never closed pin its socket for the process lifetime, which is the leak the `retired` list exists to prevent. The loop now exits on its own once the transport is closed and `retired` is empty; when `CloseGraceful` finds nothing to drain it stops the loop at once. Verified with a real 31s run that the goroutine exits after the drain.
- **`HTTP2Transport.Close` no longer early-returns on `t.closed`** (that flag now also means "graceful close in progress"). Everything it touches is idempotent: `stopCleanup` is closed through a `sync.Once`, and the lists it drains are nil after a first call. `Session` tracks a `draining` flag for the same reason, since its `Close` guards on `!active`.
- Because of that, `Session.Close` after `CloseGraceful` reaches `Transport.Close` a second time. Every sub-transport's `Close` was checked to be repeat-safe: HTTP/1.1 and HTTP/2 guard on their own state; `http3.Transport.Close` nils its lists; quic-go's `Transport.close` guards on `closeErr` and the UDP double-close error is discarded by `closeWithTimeout`; the udpbara tunnel and MASQUE conn guard on flags. A root-level test pins it in both orders, on auto and forced-H3 sessions.
- **HTTP/1.1** needs nothing: its transport only ever closes idle connections, and a checked-out one closes itself on return once the transport is closed, so `Transport.CloseGraceful` calls its plain `Close`. An e2e test pins that claim rather than leaving it to a code reading.
- **HTTP/3** has no per-request tracking at all in `HTTP3Transport` (no in-flight count, no body guard, no abandoned-body bound), so a real drain there is a separate change. For now `CloseGraceful` closes it as `Close` does, and the docs say so.
- One incidental change: `retire()` now closes an idle connection off the caller's goroutine, like every other shutdown path in the file. Every existing caller already invoked it via `go`, so nothing observable changes for them, and it keeps `CloseGraceful` from stalling for up to 250ms per connection on an unresponsive peer's TLS close.
- Known and inherent: a request that passed the closed check but had not yet reserved its connection (a few instructions wide) can still get `http2: transport closed`. That is identical to `Close` and to any check-then-use boundary; it surfaces as an error where errors are already expected.

## Tests

- `transport/close_graceful_test.go`: fake-connection unit tests in the style of the #83 tests. Idle closes now; streaming defers and new requests are refused; an abandoned body is still reclaimed after a graceful close; `Close` after graceful forces; both orders idempotent.
- `transport/close_graceful_e2e_test.go`: against real in-process servers. An HTTP/2 body mid-stream survives `CloseGraceful` and is delivered in full, new requests are refused, and the connection closes when the body ends; the same scenario under `Close` is pinned for contrast (reader is cut off); a plain `Do` in flight completes; the HTTP/1.1 stream case; a dial-vs-`CloseGraceful` race hammer publishes nothing into the closed pool.
- `close_graceful_test.go` (root, whitelisted in `.gitignore` like the other root-level regression locks): the public `Session` API via `DoStream`, and `CloseGraceful` / `Close` in both orders on auto and forced-H3 sessions.

All of `transport`, `session`, `pool`, root and `client` (minus the two tests that hit `tls.peet.ws`, whose certificate has expired) pass under `-race`; the new tests were run 25x under `-race`.

## Docs

`CHANGELOG.md` entry under Unreleased; `CloseGraceful` listed under Lifecycle on the Go bindings page; the observability page's `IsActive` statements now name both closes; one bullet in the long-running-scraper recipe's "Things to NOT do".

## Follow-ups (not in this PR)

- C API / bindings: `httpcloak_session_close_graceful` mirroring `httpcloak_session_free` (`bindings/clib` is a separate module pinned to a released version, so it has to follow a release), then the Python / Node / .NET wrappers.
- The lower-level `Client` / `pool.HostPool` stack has the same `requestClose` primitive and could get the same method.
- A real HTTP/3 drain, once `HTTP3Transport` has in-flight tracking.
