### PR TITLE
fix(transport): stop caching a soft HTTP/1.1 fallback as the host's protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **A transient failure on the first request to a host no longer pins that host to HTTP/1.1 for the rest of the session**: in auto mode the transport learns which protocol a host speaks and caches it per session, so later requests skip the negotiation (added for #68). Two different facts were being written into that cache under the same key. "This host negotiated http/1.1 via ALPN" is a property of the host and is right to cache. "The HTTP/2 attempt failed this time and the HTTP/1.1 fallback got the request through" is a property of one attempt: a reset or timed-out handshake, a first dial that did not survive, anything transient. That second case was cached exactly like the first, and only the very first request to a host (or the first after `Refresh`) could hit it, because once a host is known as HTTP/2 a later transient failure serves one request over HTTP/1.1 without touching the cache. So the failure mode was silent and permanent: one bad handshake on the opening request and every following request to that host went out over HTTP/1.1, and with it a different fingerprint, with nothing that would ever re-probe. Long-lived sessions and anything that creates sessions frequently (each new session starts with an empty cache) were the most exposed. The fallback still happens and the request still succeeds; it just no longer writes the cache, so the next request attempts HTTP/2 again and, when that works, the host is cached as HTTP/2 like any other. ALPN downgrades are cached as before, so an HTTP/1.1-only host still pays the failed HTTP/2 attempt only once. Forced protocols bypass the cache entirely and are unaffected, and so is what each request does on the wire: the fallback runs exactly as before, only the cache write is gone.
+
 ## [1.6.11] - 2026-08-17
 
 ### Added

--- a/docs/docs/http-protocols/auto-negotiation.md
+++ b/docs/docs/http-protocols/auto-negotiation.md
@@ -19,7 +19,7 @@ The dispatcher in `transport/transport.go` is one function, `doAuto`. The steps 
 3. Take the first success. Cancel the loser.
 4. If H2's TLS handshake came back with `http/1.1` in ALPN (`ALPNMismatchError`), reuse that same TLS connection for an H1 request. No second handshake.
 5. If both attempts fail (or the 6-second race budget elapses), fall through to H1 on a fresh TCP connection. There's no extra H2 retry; H2 already had its shot inside the race.
-6. Cache the winning protocol in `protocolSupport[host]` so the next request to the same host skips the race.
+6. Cache the winning protocol in `protocolSupport[host]` so the next request to the same host skips the race. Step 5's fallback is the exception: an H1 response served only because the H2 attempt failed says nothing about the host, so it is not cached, and the next request races again. An ALPN downgrade (step 4) is a fact about the host and is cached.
 
 The race lives in `raceH3H2`. It dodges the 5-second wall you'd hit when H3 went first and the network silently swallowed UDP/443. With the race, H2 fills in the moment TCP comes back, usually under 200ms.
 

--- a/transport/protocol_cache_test.go
+++ b/transport/protocol_cache_test.go
@@ -1,0 +1,192 @@
+package transport
+
+import (
+	"context"
+	"net"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sardanioss/httpcloak/fingerprint"
+)
+
+// Regression tests for the auto-mode protocol cache.
+//
+// doAuto learns the protocol a host speaks and caches it per session so later
+// requests skip the negotiation. Two very different facts were being written
+// into that cache under the same key: "this host negotiated http/1.1 via ALPN"
+// (a property of the host, correct to cache) and "the H2 attempt failed this
+// time and the HTTP/1.1 fallback got the request through" (a property of one
+// attempt). The second one, written on the very first request to a host after
+// a transient handshake failure, pinned the host to HTTP/1.1 for the rest of
+// the session with nothing that would ever re-probe it. For a fingerprinting
+// client that is a silent, permanent downgrade.
+//
+// The server below fails the first N TCP connections at accept time, which is
+// what a reset or timed-out handshake looks like from the client. The H1
+// fallback dials fresh, lands on connection N+1 and succeeds; the next request
+// must attempt H2 again and land on it.
+
+// dropFirstListener closes the first n accepted connections without serving
+// them, then behaves normally.
+type dropFirstListener struct {
+	net.Listener
+	remaining atomic.Int32
+	dropped   atomic.Int32
+}
+
+func (l *dropFirstListener) Accept() (net.Conn, error) {
+	for {
+		c, err := l.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+		if l.remaining.Add(-1) >= 0 {
+			l.dropped.Add(1)
+			c.Close()
+			continue
+		}
+		return c, nil
+	}
+}
+
+// h2ServerDroppingFirst starts an HTTP/2-capable TLS server whose first n
+// connections are refused at accept.
+func h2ServerDroppingFirst(t *testing.T, n int32) (*httptest.Server, *dropFirstListener) {
+	t.Helper()
+	srv := httptest.NewUnstartedServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		w.WriteHeader(stdhttp.StatusOK)
+	}))
+	l := &dropFirstListener{Listener: srv.Listener}
+	l.remaining.Store(n)
+	srv.Listener = l
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv, l
+}
+
+func autoTransport(t *testing.T, preset string) *Transport {
+	t.Helper()
+	if fingerprint.Get(preset) == nil {
+		t.Skipf("%s preset unavailable", preset)
+	}
+	tr := NewTransport(preset)
+	tr.SetInsecureSkipVerify(true)
+	tr.SetProtocol(ProtocolAuto)
+	t.Cleanup(tr.Close)
+	return tr
+}
+
+func cachedProtocol(tr *Transport, host string) (Protocol, bool) {
+	tr.protocolSupportMu.RLock()
+	defer tr.protocolSupportMu.RUnlock()
+	p, ok := tr.protocolSupport[host]
+	return p, ok
+}
+
+func doGet(t *testing.T, tr *Transport, rawURL string) *Response {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	resp, err := tr.Do(ctx, &Request{Method: "GET", URL: rawURL})
+	if err != nil {
+		t.Fatalf("Do(%s): %v", rawURL, err)
+	}
+	if resp.StatusCode != stdhttp.StatusOK {
+		t.Fatalf("Do(%s): status %d, want 200", rawURL, resp.StatusCode)
+	}
+	return resp
+}
+
+// A transient failure on the first request must not pin the host to HTTP/1.1.
+// Both doAuto branches are exercised: the plain H2 attempt (a preset without
+// H3 support) and the H3/H2 race (a preset with it). The race branch probes
+// before it dials, so it needs one more connection dropped to fail through to
+// the fallback.
+func TestAutoDoesNotCacheSoftH1Fallback(t *testing.T) {
+	cases := []struct {
+		name   string
+		preset string
+		drop   int32
+	}{
+		{name: "h2 branch", preset: "firefox-148", drop: 1},
+		{name: "h3 race branch", preset: "chrome-146", drop: 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := autoTransport(t, tc.preset)
+			srv, l := h2ServerDroppingFirst(t, tc.drop)
+			host := extractHost(srv.URL)
+
+			// First request: the H2 attempt hits the dropped connection(s), the
+			// HTTP/1.1 fallback dials fresh and gets through.
+			first := doGet(t, tr, srv.URL)
+			if first.Protocol != "h1" {
+				t.Fatalf("first request served over %q, want h1 (the fallback); dropped %d conns",
+					first.Protocol, l.dropped.Load())
+			}
+			if p, ok := cachedProtocol(tr, host); ok {
+				t.Fatalf("host cached as %v after a soft HTTP/1.1 fallback; a transient failure "+
+					"must not pin the protocol", p)
+			}
+
+			// Second request: nothing cached, so H2 is attempted again and wins.
+			second := doGet(t, tr, srv.URL)
+			if second.Protocol != "h2" {
+				t.Fatalf("second request served over %q, want h2: the host was pinned to the "+
+					"fallback protocol", second.Protocol)
+			}
+			if p, ok := cachedProtocol(tr, host); !ok || p != ProtocolHTTP2 {
+				t.Errorf("host cached as (%v, %v) after a successful H2 request, want ProtocolHTTP2",
+					p, ok)
+			}
+		})
+	}
+}
+
+// The other kind of HTTP/1.1, negotiated by ALPN, is a fact about the host and
+// must still be cached, so an H1-only server does not pay a failed H2 attempt
+// on every request.
+func TestAutoStillCachesALPNDowngrade(t *testing.T) {
+	for _, preset := range []string{"firefox-148", "chrome-146"} {
+		t.Run(preset, func(t *testing.T) {
+			tr := autoTransport(t, preset)
+			// NewTLSServer negotiates http/1.1 only.
+			srv := httptest.NewTLSServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+				w.WriteHeader(stdhttp.StatusOK)
+			}))
+			t.Cleanup(srv.Close)
+			host := extractHost(srv.URL)
+
+			resp := doGet(t, tr, srv.URL)
+			if resp.Protocol != "h1" {
+				t.Fatalf("served over %q, want h1", resp.Protocol)
+			}
+			if p, ok := cachedProtocol(tr, host); !ok || p != ProtocolHTTP1 {
+				t.Fatalf("host cached as (%v, %v) after an ALPN http/1.1 downgrade, want ProtocolHTTP1",
+					p, ok)
+			}
+			// And it is served straight from the cache next time.
+			if resp := doGet(t, tr, srv.URL); resp.Protocol != "h1" {
+				t.Fatalf("second request served over %q, want h1", resp.Protocol)
+			}
+		})
+	}
+}
+
+// A healthy H2 host is cached as H2 on the first request, as before.
+func TestAutoCachesH2(t *testing.T) {
+	tr := autoTransport(t, "firefox-148")
+	srv, _ := h2ServerDroppingFirst(t, 0)
+	host := extractHost(srv.URL)
+
+	if resp := doGet(t, tr, srv.URL); resp.Protocol != "h2" {
+		t.Fatalf("served over %q, want h2", resp.Protocol)
+	}
+	if p, ok := cachedProtocol(tr, host); !ok || p != ProtocolHTTP2 {
+		t.Fatalf("host cached as (%v, %v), want ProtocolHTTP2", p, ok)
+	}
+}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -1462,9 +1462,13 @@ func (t *Transport) doAuto(ctx context.Context, req *Request) (*Response, error)
 	if snap.preset.SupportHTTP3 && snap.h3 != nil {
 		resp, protocol, err := t.raceH3H2(ctx, req)
 		if err == nil {
-			t.protocolSupportMu.Lock()
-			t.protocolSupport[host] = protocol
-			t.protocolSupportMu.Unlock()
+			// ProtocolAuto means the response came from the HTTP/1.1 fallback
+			// after a non-ALPN H2 failure: nothing was learned about the host.
+			if protocol != ProtocolAuto {
+				t.protocolSupportMu.Lock()
+				t.protocolSupport[host] = protocol
+				t.protocolSupportMu.Unlock()
+			}
 			return resp, nil
 		}
 		// Check if ALPN mismatch from H2 - reuse connection
@@ -1501,16 +1505,24 @@ func (t *Transport) doAuto(ctx context.Context, req *Request) (*Response, error)
 		}
 	}
 
-	// Fallback to HTTP/1.1 with new connection
+	// Fallback to HTTP/1.1 with new connection.
+	//
+	// Deliberately not cached. Every other HTTP/1.1 entry in protocolSupport
+	// comes from an ALPN downgrade or from a preset that disables H2, both of
+	// which hold for every request to the host. This path is reached when the
+	// H2 (or H3/H2) attempt failed for any other reason, most often a transient
+	// one such as a reset or timed-out handshake, and the fallback merely got
+	// the request through. Caching it pinned the host to HTTP/1.1 for the rest
+	// of the session with nothing that would ever re-probe it, so one bad
+	// handshake on the first request to a host silently downgraded every later
+	// request, and the fingerprint with them. Leaving the host uncached costs
+	// nothing on the next request beyond re-attempting H2, which is exactly what
+	// should happen; if that succeeds the host is cached as H2.
 	resp, err := t.doHTTP1(ctx, req)
-	if err == nil {
-		t.protocolSupportMu.Lock()
-		t.protocolSupport[host] = ProtocolHTTP1
-		t.protocolSupportMu.Unlock()
-		return resp, nil
+	if err != nil {
+		return nil, err
 	}
-
-	return nil, err
+	return resp, nil
 }
 
 // connectResult holds the result of a connection race
@@ -1672,6 +1684,12 @@ func drainLateALPN(h2Done <-chan struct{}, alpnErrCh <-chan *ALPNMismatchError) 
 // raceH3H2 races HTTP/3 and HTTP/2 connections in parallel, then makes the request
 // on whichever protocol connects first. This eliminates the 5-second delay when
 // HTTP/3 (QUIC) is blocked by firewalls or VPNs.
+//
+// The returned Protocol is what was learned about the host, for the caller to
+// cache: HTTP3 or HTTP2 when that protocol connected and served the request,
+// HTTP1 when ALPN negotiated http/1.1. ProtocolAuto means the request was served
+// by the HTTP/1.1 fallback after a non-ALPN H2 failure, which says nothing about
+// the host and must not be cached. It is only meaningful when err is nil.
 func (t *Transport) raceH3H2(ctx context.Context, req *Request) (*Response, Protocol, error) {
 	// Parse URL to get host:port
 	parsedURL, err := url.Parse(req.URL)
@@ -1710,9 +1728,12 @@ func (t *Transport) raceH3H2(ctx context.Context, req *Request) (*Response, Prot
 				resp, err := t.doHTTP1WithTLSConn(ctx, req, alpnErr)
 				return resp, ProtocolHTTP1, err
 			}
-			// H2 failed for other reason, try H1 with new connection
+			// H2 failed for other reason, try H1 with new connection. This is
+			// a fallback, not a negotiation: it says nothing about what the
+			// host speaks, so report ProtocolAuto and let doAuto leave the host
+			// uncached rather than pin it to HTTP/1.1 (see doAuto's fallback).
 			resp, err = t.doHTTP1(ctx, req)
-			return resp, ProtocolHTTP1, err
+			return resp, ProtocolAuto, err
 		}
 		return resp, ProtocolHTTP2, nil
 	}


### PR DESCRIPTION
## Problem

In auto mode `doAuto` learns the protocol a host speaks and caches it per session in `protocolSupport`, so later requests skip the negotiation (added for #68). Two different facts were being written into that cache under the same key:

- **"this host negotiated http/1.1 via ALPN"**: a property of the host, correct to cache;
- **"the H2 attempt failed this time and the HTTP/1.1 fallback got the request through"**: a property of one attempt. A reset or timed-out handshake, a first dial that did not survive, anything transient.

The second was written exactly like the first, at two sites: the bottom-of-`doAuto` fallback, and, for presets with H3 support, the fallback inside `raceH3H2` (H2 failed for a non-ALPN reason, `doHTTP1` succeeded, reported back as `ProtocolHTTP1` with a nil error, which `doAuto` then cached).

Only the first request to a host (or the first after `Refresh`) can hit this: once a host is known as HTTP/2, a later transient failure serves one request over HTTP/1.1 without touching the cache. That makes the failure silent and permanent rather than rare: one bad handshake on the opening request and every following request to that host goes out over HTTP/1.1, and with it a different fingerprint, with nothing that would ever re-probe. Long-lived sessions and anything that creates sessions often (each starts with an empty cache) are the most exposed. On a direct connection the initial dial in `getOrCreateConn` is not retried (`retryDial`'s extra attempts apply only behind a proxy), so a single transient handshake failure is enough.

## Fix

The fallback runs exactly as before and the request still succeeds; it just no longer writes the cache.

- `raceH3H2` reports `ProtocolAuto` for a response it served through its H1 fallback, documented as "nothing learned about the host", and `doAuto` skips the cache write for it.
- The bottom-of-`doAuto` fallback no longer writes.

The next request attempts H2 again and, when that works, the host is cached as H2 like any other. ALPN downgrades and the `DisableHTTP2` preset branch are cached as before, so an H1-only host still pays the failed H2 attempt only once. Forced protocols never consult the cache and are unaffected.

**What each request does on the wire is unchanged.** Every path returns exactly what it returned before; the diff removes two map writes and adds comments. The stream path (`doStreamAuto`) was already correct: `doStreamHTTP2OrHTTP1` falls back to H1 only on an ALPN mismatch, so it never had a soft fallback to cache.

Precedent: the library already fixed the structurally identical "cached thing goes stale and pins a long-lived session" problem for ECH configs by making that cache self-heal. This is the protocol cache's equivalent, done by not caching what was never a fact about the host.

## Tests

`transport/protocol_cache_test.go`, all against real in-process servers:

- A listener that drops the first N TCP accepts stands in for a transient handshake failure; the H1 fallback dials fresh, lands on connection N+1 and succeeds. `TestAutoDoesNotCacheSoftH1Fallback` drives **both** `doAuto` branches: a preset without H3 support (plain H2 attempt, N=1) and one with it (race branch, N=2, because the probe connects before the dial). It asserts nothing is cached after the fallback and that the second request goes out over H2 and is then cached as H2. On the previous code it fails in both branches with `host cached as h1`.
- `TestAutoStillCachesALPNDowngrade`: an http/1.1-only server is still cached as HTTP/1.1 and served from the cache next time, on both presets.
- `TestAutoCachesH2`: a healthy H2 host is cached as H2 on the first request, as before.

`transport`, `session`, root, `pool` and `client` (minus the two tests that hit `tls.peet.ws`, whose certificate has expired) pass under `-race`. The race-branch case takes about 6s because it is the both-probes-fail path, which waits out the H3 probe budget; that is the scenario under test, not the fix.

## Docs

CHANGELOG entry under Unreleased. The auto-negotiation page (step 6) now notes that the fallback is the one case that is not cached, and why.

## Two observations, deliberately not changed here

- When both H2 and its H1 fallback fail, the H3-capable path makes a **second** H1 attempt: `raceH3H2` tries H1 itself, and `doAuto`'s bottom fallback then tries again on the non-ALPN error. Presets without H3 support get one attempt. That is inconsistent and undocumented, but removing it changes what happens on the wire in a failure case, so it is not part of this fix. Happy to send it separately if you agree it should be one attempt in one place.
- The known-`ProtocolHTTP3` branch of buffered `doAuto` has no fallback if the H3 request fails, while `doStreamAuto` falls back to H2/H1. Left as is.

Unrelated: `TestSessionDo_NonReplayableBodyOn307` in the root package is a pre-existing timing flake for me, roughly one run in ten on untouched `main` (forced H1 against a raw listener, `write: broken pipe`). Mentioning it only so a red run here is not mistaken for this change.
