### PR TITLE
fix: preserve cookie CreatedAt and honor H1 close on reuse

### DIFF
--- a/session/cookie_jar.go
+++ b/session/cookie_jar.go
@@ -95,6 +95,18 @@ func (j *CookieJar) Set(requestHost string, cookie *CookieData, requestSecure bo
 		path = "/"
 	}
 
+	// Replacing a cookie preserves its creation time. RFC 6265 requires this,
+	// and browsers use that time when ordering same-path cookies on the wire.
+	// Resetting it here moves every refreshed cookie to the end of Cookie,
+	// which is observably different from Chrome and can trip order-sensitive
+	// bot protection.
+	createdAt := time.Now()
+	if domainCookies := j.cookies[domain]; domainCookies != nil {
+		if existing := domainCookies[cookieKey(path, cookie.Name)]; existing != nil {
+			createdAt = existing.CreatedAt
+		}
+	}
+
 	// Create the stored cookie
 	stored := &CookieData{
 		Name:      cookie.Name,
@@ -107,7 +119,7 @@ func (j *CookieJar) Set(requestHost string, cookie *CookieData, requestSecure bo
 		Secure:    cookie.Secure,
 		HttpOnly:  cookie.HttpOnly,
 		SameSite:  cookie.SameSite,
-		CreatedAt: time.Now(),
+		CreatedAt: createdAt,
 	}
 
 	// Store the cookie

--- a/session/cookie_jar_test.go
+++ b/session/cookie_jar_test.go
@@ -1,0 +1,50 @@
+package session
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCookieJarReplacementPreservesHeaderOrder(t *testing.T) {
+	jar := NewCookieJar()
+	jar.Set("example.com", &CookieData{Name: "first", Value: "one", Path: "/"}, true)
+	// Windows clock resolution can make two immediate Set calls share CreatedAt.
+	// Cookie order is only defined once those times differ.
+	waitUntilClockAdvances(t, cookieCreatedAt(t, jar, "first"))
+	jar.Set("example.com", &CookieData{Name: "second", Value: "two", Path: "/"}, true)
+
+	before := cookieCreatedAt(t, jar, "first")
+	jar.Set("example.com", &CookieData{Name: "first", Value: "updated", Path: "/"}, true)
+	after := cookieCreatedAt(t, jar, "first")
+	if !after.Equal(before) {
+		t.Fatalf("replacement reset CreatedAt from %v to %v", before, after)
+	}
+
+	header := jar.BuildCookieHeader("example.com", "/", true)
+	if !strings.HasPrefix(header, "first=updated; second=two") {
+		t.Fatalf("replacement changed cookie order: %q", header)
+	}
+}
+
+func cookieCreatedAt(t *testing.T, jar *CookieJar, name string) time.Time {
+	t.Helper()
+	for _, c := range jar.Get("example.com", "/", true) {
+		if c.Name == name {
+			return c.CreatedAt
+		}
+	}
+	t.Fatalf("cookie %q not found", name)
+	return time.Time{}
+}
+
+func waitUntilClockAdvances(t *testing.T, previous time.Time) {
+	t.Helper()
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for !time.Now().After(previous) {
+		if time.Now().After(deadline) {
+			t.Fatal("clock did not advance")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/transport/http1_reuse_test.go
+++ b/transport/http1_reuse_test.go
@@ -1,0 +1,79 @@
+package transport
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	http "github.com/sardanioss/http"
+)
+
+func TestHTTP1ShouldKeepAliveHonorsParsedClose(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.test/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(strings.NewReader(
+		"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n")), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if !resp.Close {
+		t.Fatal("parsed response did not record Connection: close")
+	}
+	if (&HTTP1Transport{}).shouldKeepAlive(req, resp) {
+		t.Fatal("Connection: close response was marked reusable")
+	}
+}
+
+func TestHTTP1ShouldKeepAliveHonorsRequestClose(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.test/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Close = true
+	resp := &http.Response{ProtoMajor: 1, ProtoMinor: 1, Header: make(http.Header)}
+	if (&HTTP1Transport{}).shouldKeepAlive(req, resp) {
+		t.Fatal("request with Close set was marked reusable")
+	}
+}
+
+func TestRewindRequestBody(t *testing.T) {
+	want := []byte("sensor-payload")
+	req, err := http.NewRequest("POST", "http://example.test/", bytes.NewReader(want))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadAll(req.Body); err != nil {
+		t.Fatal(err)
+	}
+	if err := req.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rewindRequestBody(req); err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("rewound body = %q, want %q", got, want)
+	}
+}
+
+func TestRewindRequestBodyRejectsNonReplayableBody(t *testing.T) {
+	req, err := http.NewRequest("POST", "http://example.test/", io.NopCloser(strings.NewReader("payload")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.GetBody != nil {
+		t.Fatal("test body unexpectedly replayable")
+	}
+	if err := rewindRequestBody(req); err == nil {
+		t.Fatal("non-replayable body was accepted")
+	}
+}

--- a/transport/http1_transport.go
+++ b/transport/http1_transport.go
@@ -3,12 +3,12 @@ package transport
 import (
 	"bufio"
 	"context"
-	tls "github.com/sardanioss/utls"
 	"encoding/base64"
 	"fmt"
+	http "github.com/sardanioss/http"
+	tls "github.com/sardanioss/utls"
 	"io"
 	"net"
-	http "github.com/sardanioss/http"
 	"net/textproto"
 	"net/url"
 	"sort"
@@ -345,15 +345,11 @@ func (t *HTTP1Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		// anything wrong. GetBody is set by http.NewRequestWithContext for every
 		// in-memory body; one that cannot be re-opened cannot be retried at all,
 		// so the connection error stands rather than a corrupt request going out.
-		if req.Body != nil && req.Body != http.NoBody {
+		if rewindErr := rewindRequestBody(req); rewindErr != nil {
 			if req.GetBody == nil {
 				return nil, WrapError("request", host, port, "h1", err)
 			}
-			rc, gerr := req.GetBody()
-			if gerr != nil {
-				return nil, WrapError("request", host, port, "h1", gerr)
-			}
-			req.Body = rc
+			return nil, WrapError("request", host, port, "h1", rewindErr)
 		}
 	}
 
@@ -386,6 +382,25 @@ func (t *HTTP1Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	return resp, nil
+}
+
+// rewindRequestBody restores a request body after an attempt on a pooled
+// connection consumed it. Retrying with the exhausted reader would preserve
+// Content-Length while sending no bytes, leaving the peer waiting for a body
+// and the client waiting for response headers until the request deadline.
+func rewindRequestBody(req *http.Request) error {
+	if req.Body == nil || req.Body == http.NoBody {
+		return nil
+	}
+	if req.GetBody == nil {
+		return fmt.Errorf("request body cannot be replayed")
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return fmt.Errorf("rewind request body: %w", err)
+	}
+	req.Body = body
+	return nil
 }
 
 // RoundTripWithTLSConn performs an HTTP/1.1 request using an existing TLS connection.
@@ -1426,8 +1441,20 @@ func (t *HTTP1Transport) writeHeadersInOrder(w *bufio.Writer, req *http.Request,
 
 // shouldKeepAlive determines if connection should be reused
 func (t *HTTP1Transport) shouldKeepAlive(req *http.Request, resp *http.Response) bool {
+	// ReadResponse records connection-close semantics in Response.Close. Some
+	// HTTP implementations remove the hop-by-hop Connection header after parsing,
+	// so checking the header alone can incorrectly return a closing socket to the
+	// idle pool.
+	if resp.Close {
+		return false
+	}
+
 	// Check response Connection header
 	if strings.EqualFold(resp.Header.Get("Connection"), "close") {
+		return false
+	}
+
+	if req.Close {
 		return false
 	}
 


### PR DESCRIPTION
## Summary
- Cookie replacement now keeps the original `CreatedAt` so same-path `Cookie` order stays Chrome/RFC 6265-like instead of moving every refreshed cookie to the end of the header.
- `shouldKeepAlive` now honors `Response.Close` and `Request.Close`. Some HTTP parsers strip the hop-by-hop `Connection` header, so a closing socket could previously be returned to the idle pool.
- Pooled HTTP/1 retries already rewound bodies via `GetBody` on current main. That path now shares a `rewindRequestBody` helper, with tests for replayable and non-replayable bodies.

## Test plan
- [x] `go test ./transport -run 'TestHTTP1ShouldKeepAlive|TestRewindRequestBody'` passed on this machine
- [ ] `go test ./session -run TestCookieJarReplacementPreservesHeaderOrder` — test was updated to wait for a distinct Windows clock tick; please re-run in CI / a Go-on-PATH environment
- [ ] `go test ./session ./transport`

## Risk
Low. Cookie order only changes when a cookie is replaced (now matches browsers). Keep-alive becomes more conservative when Close is set. Rewind helper preserves existing main retry error behavior (non-replayable body still surfaces the original connection error).

## Merge
Ready for review. **Do not auto-merge** — please review and merge on GitHub.

Made with [Cursor](https://cursor.com)